### PR TITLE
DS-132 - As LU I want to cancel my account

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_user/social_user.install
+++ b/public_html/profiles/social/modules/social_features/social_user/social_user.install
@@ -18,5 +18,7 @@ function social_user_install() {
   user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, array(
     'change own username',
     'access user profiles',
+    'cancel account',
+    'select account cancellation method',
   ));
 }

--- a/public_html/profiles/social/modules/social_features/social_user/social_user.module
+++ b/public_html/profiles/social/modules/social_features/social_user/social_user.module
@@ -46,3 +46,16 @@ function social_user_entity_base_field_info_alter(&$fields, EntityTypeInterface 
     $fields['name']->addConstraint('SocialUserName');
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function social_user_form_user_cancel_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  // Fetch the current user.
+  $account = \Drupal::currentUser();
+  // Check if the user has permissions.
+  if ($account->hasPermission('administer account settings') === FALSE) {
+    // Remove the option to cancel account and delete all related content.
+    unset($form['user_cancel_method']['#options']['user_cancel_delete']);
+  }
+}


### PR DESCRIPTION
**HTT**

- Perform a new installation of the site, since some permissions were added

- Create a new account (user_role => authenticated user)

- Login as the new user

- Edit your own account

- Notice the 'cancel account' button next to the save button

- Click it!

- Notice there are only 3 options to choose from. It's no longer possible to choose 'Delete the account and its content.'

- Choose one of the options (it will fail since no mail was send :-1: )

- Login as an administrator. Notice the option is still there.

- Execute manual test [DS-391](https://goalgorilla.cloudshards.net/browse/DS-391) in [DS-387](https://goalgorilla.cloudshards.net/browse/DS-387)

As an admin I can also access this form from the people overview (bulk operation). No changes were made here, since the 'administer account settings' permission is required to go to this overview. With that permission in mind I've made the decision to remove the 'user_cancel_delete' option using that same permission. So if a user does NOT have the 'administer account settings' permission, the 'user_cancel_delete' option WILL be removed.
