### PR TITLE
DS-639 - As a LU I want to see which group the content belongs to

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_core/social_core.module
+++ b/public_html/profiles/social/modules/social_features/social_core/social_core.module
@@ -18,6 +18,7 @@ function social_core_theme() {
         'created_date' => NULL,
         'created_date_formatted' => NULL,
         'topic_type' => NULL,
+        'group_link' => NULL,
         'hero_node' => NULL,
       ),
     ),

--- a/public_html/profiles/social/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
+++ b/public_html/profiles/social/modules/social_features/social_core/src/Plugin/Block/SocialPageTitleBlock.php
@@ -38,17 +38,20 @@ class SocialPageTitleBlock extends PageTitleBlock {
       $title = $node->getTitle();
       $author = $node->getOwner();
       $author_name = $author->link();
+      $group_link = NULL;
 
-      switch($node->getType()) {
+      switch ($node->getType()) {
         case 'topic':
           $topic_type = $node->get('field_topic_type');
           $hero_node = NULL;
+          $group_link = $this->getGroupLink($node);
           break;
 
         case 'event':
           // @todo make link to events overview.
           $topic_type = NULL;
           $hero_node = node_view($node, 'hero');
+          $group_link = $this->getGroupLink($node);
           break;
 
         default:
@@ -62,6 +65,7 @@ class SocialPageTitleBlock extends PageTitleBlock {
         '#author_name' => $author_name,
         '#created_date' => $node->getCreatedTime(),
         '#topic_type' => $topic_type,
+        '#group_link' => $group_link,
         '#hero_node' => $hero_node,
       ];
     }
@@ -75,6 +79,23 @@ class SocialPageTitleBlock extends PageTitleBlock {
         '#title' => $title,
       ];
     }
+  }
+
+  /**
+   * Prepare group link when an event or topic belongs to one group.
+   */
+  protected function getGroupLink($node) {
+    $group_link = NULL;
+    $group_content = \Drupal::entityTypeManager()
+      ->getStorage('group_content')
+      ->loadByProperties([
+        'entity_id' => $node->id()
+      ]);
+    if (!empty($group_content)) {
+      $group = reset($group_content)->getGroup();
+      $group_link = $group->link();
+    }
+    return $group_link;
   }
 
 }

--- a/public_html/profiles/social/modules/social_features/social_core/templates/page-hero-data.html.twig
+++ b/public_html/profiles/social/modules/social_features/social_core/templates/page-hero-data.html.twig
@@ -29,9 +29,17 @@
 {% endif %}
 
 {% if author_name and created_date_formatted %}
-{% trans %}By {{ author_name }} on {{ created_date_formatted }}{% endtrans %}
+    {% trans %}By {{ author_name }} on {{ created_date_formatted }}{% endtrans %}
 {% endif %}
 
-{% if topic_type %}
-{% trans %}in {{ topic_type }}{% endtrans %}
-{% endif %}
+<div>
+    {% if topic_type %}
+        <i class="material-icons">label</i>
+        {{ topic_type }}
+    {% endif %}
+
+    {% if group_link %}
+        <i class="custom-icons icon-group"></i>
+        {{ group_link }}
+    {% endif %}
+</div>


### PR DESCRIPTION
# Changes 
- Added group link to page title hero block when an event or topic belongs to the group.

# HTT
- [x] Checkout to the branch
- [x] Reinstall the site
- [x] Create a Group (remember ID of this group)
- [x] Add normal user to this group
- [x] Login as normal user
- [x] Add topic to this group `group/%/node/create/topic`
- [x] Add event to this group `group/%/node/create/event`
- [x] Go to `admin/content`
- [x] Check that nodes created in groups has link to the group
- [x] Check that nodes not created in groups has not link to the group