### PR TITLE
DS-648 - As a LU I want to see the members of a group

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_group/config/install/block.block.views_block__group_members_block_newest_members.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/block.block.views_block__group_members_block_newest_members.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.group_members
+  module:
+    - system
+    - views
+  theme:
+    - socialbase
+id: views_block__group_members_block_newest_members
+theme: socialbase
+region: complementary
+weight: -17
+provider: null
+plugin: 'views_block:group_members-block_newest_members'
+settings:
+  id: 'views_block:group_members-block_newest_members'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: '/group/*'
+    negate: false
+    context_mapping: {  }

--- a/public_html/profiles/social/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_membership.default.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/core.entity_view_display.group_content.open_group-group_membership.default.yml
@@ -9,13 +9,12 @@ targetEntityType: group_content
 bundle: open_group-group_membership
 mode: default
 content:
-  group_roles:
-    label: above
-    type: entity_reference_label
-    settings:
-      link: false
-    weight: -4
+  entity_id:
+    type: entity_reference_entity_id
+    weight: 0
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
 hidden:
-  entity_id: true
+  group_roles: true
   uid: true

--- a/public_html/profiles/social/modules/social_features/social_group/config/install/views.view.group_members.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/views.view.group_members.yml
@@ -1,0 +1,232 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.content_type.open_group-group_membership
+  module:
+    - group
+    - user
+id: group_members
+label: 'Group Members'
+module: views
+description: ''
+tag: ''
+base_table: group_content_field_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+      row:
+        type: 'entity:group_content'
+        options:
+          relationship: none
+          view_mode: default
+      fields:
+        label:
+          table: group_content_field_data
+          field: label
+          id: label
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        type:
+          id: type
+          table: group_content_field_data
+          field: type
+          value:
+            open_group-group_membership: open_group-group_membership
+          entity_type: group_content
+          entity_field: type
+          plugin_id: bundle
+      sorts: {  }
+      title: 'Group Members'
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No results found.'
+            format: basic_html
+          plugin_id: text
+      relationships: {  }
+      arguments:
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: numeric
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_group_members:
+    display_plugin: page
+    id: page_group_members
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: group/%group/members
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/public_html/profiles/social/modules/social_features/social_group/config/install/views.view.group_members.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/views.view.group_members.yml
@@ -53,6 +53,9 @@ display:
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -61,9 +64,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
       style:
         type: default
       row:
@@ -146,7 +146,14 @@ display:
           entity_type: group_content
           entity_field: type
           plugin_id: bundle
-      sorts: {  }
+      sorts:
+        created:
+          id: created
+          table: group_content_field_data
+          field: created
+          entity_type: group_content
+          entity_field: created
+          plugin_id: date
       title: 'Group Members'
       header: {  }
       footer: {  }
@@ -211,6 +218,49 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
+      tags: {  }
+  block_newest_members:
+    display_plugin: block
+    id: block_newest_members
+    display_title: Block
+    position: 2
+    display_options:
+      display_extenders: {  }
+      title: 'Newest Members'
+      defaults:
+        title: false
+        pager: false
+        sorts: false
+        empty: false
+      pager:
+        type: some
+        options:
+          items_per_page: 2
+          offset: 0
+      sorts:
+        created:
+          id: created
+          table: group_content_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: group_content
+          entity_field: created
+          plugin_id: date
+      empty: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
         - user.permissions
       tags: {  }
   page_group_members:

--- a/public_html/profiles/social/modules/social_features/social_group/social_group.links.task.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.links.task.yml
@@ -2,3 +2,8 @@ social_user.groups:
   route_name: view.groups.user_groups
   base_route: entity.user.canonical
   title: Groups
+
+social_group.members:
+  route_name: view.group_members.page_group_members
+  base_route: entity.group.canonical
+  title: Members

--- a/public_html/profiles/social/modules/social_features/social_group/social_group.module
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.module
@@ -121,3 +121,13 @@ function social_group_views_post_render(ViewExecutable $view, &$output, CachePlu
     }
   }
 }
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function social_group_menu_local_tasks_alter(&$data, $route_name) {
+  // Hide default Group "Members" tab, because we add our own tab.
+  if (isset($data['tabs'][0]['group.members'])){
+    unset($data['tabs'][0]['group.members']);
+  }
+}

--- a/public_html/profiles/social/modules/social_features/social_group/social_group.module
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.module
@@ -107,10 +107,12 @@ function social_group_views_post_render(ViewExecutable $view, &$output, CachePlu
           // Get Profile entity.
           $user_profile = $storage->loadByUser($user_entity, 'profile');
           if ($user_profile) {
+            // Use teaser for page and small_teaser for block.
+            $view_mode = ($view->current_display === 'block_newest_members') ? 'small_teaser' : 'teaser';
             // Replace output with profile teaser.
             $output['#rows'][0]['#rows'][$key] = \Drupal::entityTypeManager()
               ->getViewBuilder('profile')
-              ->view($user_profile, 'teaser');
+              ->view($user_profile, $view_mode);
           }
           else {
             // Remove output if user don't have profile (admin).

--- a/public_html/profiles/social/modules/social_features/social_group/social_group.module
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.module
@@ -4,6 +4,8 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupContent;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Plugin\views\cache\CachePluginBase;
 
 /**
  * @file
@@ -37,7 +39,7 @@ function _social_group_group_open_group_edit_form_submit($form, FormStateInterfa
   // Set redirect to the group overview page when user saves a group.
   $form_state->setRedirect(
     'view.groups.user_groups',
-    array('user' =>\Drupal::currentUser()->id(), array())
+    array('user' => \Drupal::currentUser()->id(), array())
   );
 }
 
@@ -82,5 +84,40 @@ function social_group_group_insert(GroupInterface $group) {
         'entity_id' => $group->getOwnerId(),
       ] + $values);
     $group_content->save();
+  }
+}
+
+
+/**
+ * Implements hook_views_post_render().
+ *
+ * Alter "Group Members" views. Replace user IDs with profile teasers.
+ */
+function social_group_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
+  if ($view->id() == 'group_members') {
+    foreach ($output['#rows'][0]['#rows'] as $key => $row) {
+      // Get Group membership content entity.
+      $group_content = $row['#group_content'];
+      // Get User entity.
+      $user_entity = $group_content->getEntity();
+      if (!empty($user_entity)) {
+        // Get Profile storage.
+        $storage = \Drupal::entityTypeManager()->getStorage('profile');
+        if (!empty($storage)) {
+          // Get Profile entity.
+          $user_profile = $storage->loadByUser($user_entity, 'profile');
+          if ($user_profile) {
+            // Replace output with profile teaser.
+            $output['#rows'][0]['#rows'][$key] = \Drupal::entityTypeManager()
+              ->getViewBuilder('profile')
+              ->view($user_profile, 'teaser');
+          }
+          else {
+            // Remove output if user don't have profile (admin).
+            unset($output['#rows'][0]['#rows'][$key]);
+          }
+        }
+      }
+    }
   }
 }

--- a/public_html/profiles/social/modules/social_features/social_group/social_group.services.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_group.route_subscriber:
+    class: Drupal\social_group\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/public_html/profiles/social/modules/social_features/social_group/src/Controller/SocialGroupController.php
+++ b/public_html/profiles/social/modules/social_features/social_group/src/Controller/SocialGroupController.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\social_group\Entity\Controller\SocialGroupController.
+ */
+
+namespace Drupal\social_group\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Returns responses for Social Group routes.
+ */
+class SocialGroupController extends ControllerBase {
+
+  /**
+   * The _title_callback for the view.group_members.page_group_members route.
+   *
+   * @param $group
+   *   The group ID.
+   *
+   * @return string
+   *   The page title.
+   */
+  public function groupMembersTitle($group) {
+    $storage = \Drupal::entityTypeManager()->getStorage('group');
+    $group_entity = $storage->load($group);
+    $group_label = empty($group_entity) ? 'group' : $group_entity->label();
+    return $this->t('Members of @name', ['@name' => $group_label]);
+  }
+
+}

--- a/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
+++ b/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
@@ -26,6 +26,12 @@ class RouteSubscriber extends RouteSubscriberBase {
     if ($route = $collection->get('entity.group_content.group_membership.collection')) {
       $route->setPath('/group/{group}/membership');
     }
+    // Override default title
+    if ($route = $collection->get('view.group_members.page_group_members')) {
+      $defaults = $route->getDefaults();
+      $defaults['_title_callback'] = '\Drupal\social_group\Controller\SocialGroupController::groupMembersTitle';
+      $route->setDefaults($defaults);
+    }
   }
 
 }

--- a/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
+++ b/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\social_group\Routing\RouteSubscriber.
+ */
+
+namespace Drupal\social_group\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class RouteSubscriber.
+ *
+ * @package Drupal\social_user\Routing
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Route the group members page to the group/{group}/membership
+    if ($route = $collection->get('entity.group_content.group_membership.collection')) {
+      $route->setPath('/group/{group}/membership');
+    }
+  }
+
+}

--- a/public_html/themes/socialbase/socialbase.theme
+++ b/public_html/themes/socialbase/socialbase.theme
@@ -66,6 +66,11 @@ function _socialbase_call_preprocess_page($hook, &$variables) {
  */
 function socialbase_preprocess_block(&$variables) {
   $variables['content']['#attributes']['block'] = $variables['attributes']['id'];
+  // Add group id for "See all groups link".
+  if ($variables['derivative_plugin_id'] === 'group_members-block_newest_members') {
+    $group = \Drupal::routeMatch()->getParameter('group');
+    $variables['group_id'] = $group->id();
+  }
 }
 
 /**

--- a/public_html/themes/socialbase/templates/block/block--views-block--group_members-block-newest-members.html.twig
+++ b/public_html/themes/socialbase/templates/block/block--views-block--group_members-block-newest-members.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main content
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="card-with-actionbar">
+    <div class="card-head">
+        <header class="text-center">   {{ title_prefix }} {{ label }} {{ title_suffix }} </header>
+        <div class="subtitle text-center">
+            {% trans %}in the group{% endtrans %}
+        </div>
+    </div>
+    <div class="card-body">
+        <div class="list-group list-group-divider">
+            {{ content }}
+        </div>
+        <div class="card-actionbar text-center">
+            <a href="/group/{{ group_id }}/members" class="btn btn-flat">
+                {% trans %}
+                See all
+                {% endtrans %}
+            </a>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
# Changes

- Added "Group Members" views. Alter output of this view with profile teasers
- Replaced default Group "Members" page with views "Group Members" page
- Added "Newest Members" block to the Group page

# HTT

- [x] Checkout to the branch
- [x] Reinstall the site
- [x] Create a Group (remember ID of this group)
- [x] Add few normal users to this group from page `group/1/membership`
- [x] Login as normal user
- [x] Go to the Group Members page `group/%/members`
- [x] Check that profile teasers of added users are displayed
- [x] Go to the Group Stream page (for now `group/%`)
- [x] Check that "Newest Members" block are in sidebar