### PR TITLE
DS-705 by jochemvn: Remove local tab delete from group homepage

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_group/social_group.module
+++ b/public_html/profiles/social/modules/social_features/social_group/social_group.module
@@ -127,3 +127,11 @@ function _social_group_node_form_submit($form, FormStateInterface $form_state) {
     );
   }
 }
+
+/**
+ * Implements hook_local_tasks_alter().
+ */
+function social_group_local_tasks_alter(&$local_tasks) {
+  // Remove local delete task from group page.
+  unset($local_tasks['group.delete_form']);
+}


### PR DESCRIPTION
**HTT**

- [x] Login as LU
- [x] Create a group and go to the group homepage
- [x] Notice there is no longer a delete tab
- [x] Click edit
- [x] See you can delete the group at the bottom
- [x] Delete the group
- [x] Yeah it's gone