### PR TITLE
DS-707 - GM Should edit content of others in a group

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
@@ -9,7 +9,6 @@ weight: -99
 internal: false
 group_type: open_group
 permissions:
-  - 'administer group'
   - 'delete group'
   - 'edit group'
   - 'view group'


### PR DESCRIPTION
Revoked 'administrer group' permission for group mangers. This overrides all other permissions.

**HTT:**

- [x] Re-install the site (or revoke the permission manually from the open_group permissions)
- [x] Login as a normal LU
- [x] Create a group
- [x] Login as a different LU, join the group and create a topic and event
- [x] Login as the GM again
- [x] Notice you cannot edit/delete the topic/event
- [x] Also notice you still can edit/delete the group and add/remove members