### PR TITLE
DS-722 by jaapjan: outsiders are not allowed to enrol to an event in group

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_event/social_event.group.permissions.yml
+++ b/public_html/profiles/social/modules/social_features/social_event/social_event.group.permissions.yml
@@ -1,0 +1,2 @@
+enroll to events in groups:
+  title: 'Enroll to events posted inside this group'

--- a/public_html/profiles/social/modules/social_features/social_event/src/Controller/SocialEventController.php
+++ b/public_html/profiles/social/modules/social_features/social_event/src/Controller/SocialEventController.php
@@ -16,7 +16,6 @@ use Drupal\Core\Controller\ControllerBase;
  */
 class SocialEventController extends ControllerBase {
 
-
   /**
    * Redirectmyevents.
    *

--- a/public_html/profiles/social/modules/social_features/social_event/src/Plugin/Block/EnrollActionBlock.php
+++ b/public_html/profiles/social/modules/social_features/social_event/src/Plugin/Block/EnrollActionBlock.php
@@ -10,6 +10,8 @@ namespace Drupal\social_event\Plugin\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\Group;
+use Drupal\group\Entity\GroupContent;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 
 /**
@@ -37,7 +39,19 @@ class EnrollActionBlock extends BlockBase {
       }
 
       if (is_object($node) && $node->getType() === 'event') {
-        return AccessResult::allowed();
+        // Retrieve the group and if there are groups respect group permission.
+        $groups = $this->getGroups($node);
+        if (!empty($groups)) {
+          foreach ($groups as $group) {
+            if ($group->hasPermission('enroll to events in group', $account)) {
+              return AccessResult::allowed();
+            }
+          }
+        }
+        else {
+          // @TODO Always show the block when the user is already enrolled.
+          return AccessResult::allowed();
+        }
       }
     }
     // By default, the block is not visible.
@@ -64,6 +78,31 @@ class EnrollActionBlock extends BlockBase {
     }
 
     return $render_array;
+  }
+
+  /**
+   * Get group object where event enrollment is posted in.
+   *
+   * Returns an array of Group Objects.
+   *
+   * @return array $groups
+   */
+  public function getGroups($node) {
+
+    $groupcontents = GroupContent::loadByEntity($node);
+
+    $groups = [];
+    // Only react if it is actually posted inside a group.
+    if (!empty($groupcontents)) {
+      foreach ($groupcontents as $groupcontent) {
+        /** @var \Drupal\group\Entity\GroupContent $groupcontent */
+        $group = $groupcontent->getGroup();
+        /** @var \Drupal\group\Entity\Group $group*/
+        $groups[] = $group;
+      }
+    }
+
+    return $groups;
   }
 
 }

--- a/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-group_manager.yml
@@ -32,3 +32,4 @@ permissions:
   - 'delete any topic node'
   - 'access posts in group'
   - 'add post entities in group'
+  - 'enroll to events in groups'

--- a/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-member.yml
+++ b/public_html/profiles/social/modules/social_features/social_group/config/install/group.role.open_group-member.yml
@@ -26,3 +26,4 @@ permissions:
   14: 'view group'
   15: 'access posts in group'
   32: 'add post entities in group'
+  23: 'enroll to events in groups'

--- a/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
+++ b/public_html/profiles/social/modules/social_features/social_group/src/Routing/RouteSubscriber.php
@@ -30,11 +30,11 @@ class RouteSubscriber extends RouteSubscriberBase {
       $route->setDefaults($defaults);
     }
 
-
     // Route the group members page to the group/{group}/membership
     if ($route = $collection->get('entity.group_content.group_membership.collection')) {
       $route->setPath('/group/{group}/membership');
     }
+
     // Override default title
     if ($route = $collection->get('view.group_members.page_group_members')) {
       $defaults = $route->getDefaults();


### PR DESCRIPTION
If an event is posted inside a group we have to use custom permission checks to make sure the user is allowed to enrol to the event.