### PR TITLE
DS-1188: Theme create comment reply functionality

### DIFF
--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -32,6 +32,9 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
   // The reply to comment form should be different from default comment form.
   if(\Drupal::routeMatch()->getRouteName() === 'comment.reply'){
     $form['actions']['submit']['#value'] = t('Reply');
+    $form['actions']['submit']['#button_type'] = 'flat';
+    $form['actions']['submit']['#attributes']['class'][] = 'btn-link';
+
     $form['field_comment_body']['widget'][0]['#placeholder'] = t('Add a reply');
   }
 }

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -100,6 +100,9 @@ function social_comment_preprocess_comment(&$variables) {
     ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 2));
   $submitted = t('@time ago', array('@time' => $created_time_ago));
 
+  dpm($variables['elements']);
+//  dpm($submitted);
+
   $variables['submitted'] = Link::fromTextAndUrl($submitted, $comment->urlInfo('canonical'));
 
   $account = $comment->getOwner();

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -28,6 +28,12 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
   }
   // Validate replies to comments deeper than 1.
   $form['#validate'][] = 'social_comment_form_reply_validate';
+
+  // The reply to comment form should be different from default comment form.
+  if(\Drupal::routeMatch()->getRouteName() === 'comment.reply'){
+    $form['actions']['submit']['#value'] = t('Reply');
+    $form['field_comment_body']['widget'][0]['#placeholder'] = t('Add a reply');
+  }
 }
 
 /**
@@ -64,7 +70,7 @@ function social_comment_comment_links_alter(array &$links, CommentInterface $ent
   $bundle = $entity->bundle();
   switch ($bundle) {
     default:
-      if (!empty($entity->getParentComment())) {
+      if (!empty($entity->getParentComment()) || \Drupal::routeMatch()->getRouteName() === 'comment.reply') {
         unset($links['comment']['#links']['comment-reply']);
       }
       break;

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -99,10 +99,7 @@ function social_comment_preprocess_comment(&$variables) {
   $created_time_ago = \Drupal::service('date.formatter')
     ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 2));
   $submitted = t('@time ago', array('@time' => $created_time_ago));
-
-  dpm($variables['elements']);
-//  dpm($submitted);
-
+  
   $variables['submitted'] = Link::fromTextAndUrl($submitted, $comment->urlInfo('canonical'));
 
   $account = $comment->getOwner();

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -31,8 +31,8 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
 
   // The reply to comment form should be different from default comment form.
   if(\Drupal::routeMatch()->getRouteName() === 'comment.reply'){
+    $form['#attributes']['class'][] = 'card-nested-section';
     $form['actions']['submit']['#value'] = t('Reply');
-    $form['actions']['submit']['#button_type'] = 'flat';
     $form['actions']['submit']['#attributes']['class'][] = 'btn-link';
 
     $form['field_comment_body']['widget'][0]['#placeholder'] = t('Add a reply');

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -41,6 +41,7 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
   if(\Drupal::routeMatch()->getRouteName() === 'entity.comment.edit_form'){
     $form['actions']['submit']['#value'] = t('Submit');
     $form['#title'] = t('Edit comment');
+    $form['field_comment_body']['widget'][0]['#attributes']['class'][] = 'form-control materialize-textarea';
   }
 }
 

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -29,13 +29,17 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
   // Validate replies to comments deeper than 1.
   $form['#validate'][] = 'social_comment_form_reply_validate';
 
-  // The reply to comment form should be different from default comment form.
+  // Comment reply form.
   if(\Drupal::routeMatch()->getRouteName() === 'comment.reply'){
     $form['#attributes']['class'][] = 'card-nested-section';
     $form['actions']['submit']['#value'] = t('Reply');
     $form['actions']['submit']['#attributes']['class'][] = 'btn-link';
 
     $form['field_comment_body']['widget'][0]['#placeholder'] = t('Add a reply');
+  }
+  // Comment edit form.
+  if(\Drupal::routeMatch()->getRouteName() === 'entity.comment.edit_form'){
+    $form['actions']['submit']['#value'] = t('Submit');
   }
 }
 

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -40,6 +40,7 @@ function social_comment_form_comment_form_alter(&$form, \Drupal\Core\Form\FormSt
   // Comment edit form.
   if(\Drupal::routeMatch()->getRouteName() === 'entity.comment.edit_form'){
     $form['actions']['submit']['#value'] = t('Submit');
+    $form['#title'] = t('Edit comment');
   }
 }
 

--- a/public_html/profiles/social/modules/social_features/social_comment/src/Routing/RouteSubscriber.php
+++ b/public_html/profiles/social/modules/social_features/social_comment/src/Routing/RouteSubscriber.php
@@ -28,6 +28,15 @@ class RouteSubscriber extends RouteSubscriberBase {
         '_controller' => '\Drupal\social_comment\Controller\SocialCommentController::commentPermalink',
       ));
     }
+
+    // Override default title for comment reply page
+    // @TODO: For some reason this doesn't work.
+    if ($route = $collection->get('comment.reply')) {
+      $defaults = $route->getDefaults();
+      $defaults['_title'] = 'Add new reply';
+      $route->setDefaults($defaults);
+    }
+
   }
 
 }

--- a/public_html/profiles/social/modules/social_features/social_comment/src/SocialCommentBreadcrumbBuilder.php
+++ b/public_html/profiles/social/modules/social_features/social_comment/src/SocialCommentBreadcrumbBuilder.php
@@ -57,6 +57,7 @@ class SocialCommentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $breadcrumb = new Breadcrumb();
     $breadcrumb->addCacheContexts(['route']);
     $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
 
     switch ($route_match->getRouteName()) {
       case 'comment.reply':

--- a/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-edit.feature
+++ b/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-edit.feature
@@ -17,5 +17,5 @@ Feature: Edit Comment
     And I should see "This is my comment"
     When I fill in the following:
       | Add a comment | This is my edited comment |
-    And I press "Comment"
+    And I press "Submit"
     And I should see "This is my edited comment"

--- a/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-view-thread.feature
+++ b/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-view-thread.feature
@@ -15,7 +15,7 @@ Feature: See Comment
     When I click "Reply"
     And I fill in the following:
       | Add a reply | This is a reply comment |
-    And I press "Comment"
+    And I press "Reply"
     And I should see "This is a reply comment"
     When I fill in the following:
       | Add a comment | This is a second comment |

--- a/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-view-thread.feature
+++ b/public_html/profiles/social/tests/behat/features/capabilities/comment/comment-view-thread.feature
@@ -14,7 +14,7 @@ Feature: See Comment
     Then I should see the link "Reply"
     When I click "Reply"
     And I fill in the following:
-      | Add a comment | This is a reply comment |
+      | Add a reply | This is a reply comment |
     And I press "Comment"
     And I should see "This is a reply comment"
     When I fill in the following:

--- a/public_html/profiles/social/tests/behat/features/capabilities/post/post-comments.feature
+++ b/public_html/profiles/social/tests/behat/features/capabilities/post/post-comments.feature
@@ -32,7 +32,7 @@ Feature: Comment on a Post
   When I click the xth "2" element with the css ".dropdown-toggle"
     And I click "Edit"
     And I fill in "Comment #1 to be deleted" for "field_comment_body[0][value]"
-    And I press "Comment"
+    And I press "Submit"
    Then I should see the success message "Your comment has been posted."
 
         # Scenario: delete comment

--- a/public_html/profiles/social/themes/socialbase/css/materialize.css
+++ b/public_html/profiles/social/themes/socialbase/css/materialize.css
@@ -5056,6 +5056,18 @@ label .custom-icons {
   line-height: inherit;
 }
 
+form.card-nested-section {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+form.card-nested-section:last-child {
+  margin-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .form-group {
   position: relative;
 }

--- a/public_html/profiles/social/themes/socialbase/css/src/materialize/_forms.scss
+++ b/public_html/profiles/social/themes/socialbase/css/src/materialize/_forms.scss
@@ -8,6 +8,19 @@ label {
   }
 }
 
+form {
+  &.card-nested-section {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    &:last-child {
+      margin-bottom: 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+}
+
 .form-group {
   position: relative;
 }

--- a/public_html/profiles/social/themes/socialbase/jade/reply-edit.jade
+++ b/public_html/profiles/social/themes/socialbase/jade/reply-edit.jade
@@ -25,7 +25,7 @@ block content
               .media-body
                 h5.media-heading
                   a(href="my-stream.html") John Johnson 
-                  | &bullet;
+                  | &bullet;  
                   small 6 hours ago
                 form(action="comment.html")
                   .form-group

--- a/public_html/profiles/social/themes/socialbase/jade/reply-edit.jade
+++ b/public_html/profiles/social/themes/socialbase/jade/reply-edit.jade
@@ -25,8 +25,7 @@ block content
               .media-body
                 h5.media-heading
                   a(href="my-stream.html") John Johnson 
-                  | &bullet; 
-                  br                  
+                  | &bullet;
                   small 6 hours ago
                 form(action="comment.html")
                   .form-group

--- a/public_html/profiles/social/themes/socialbase/socialbase.theme
+++ b/public_html/profiles/social/themes/socialbase/socialbase.theme
@@ -6,6 +6,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\Html as HtmlUtility;
+use Drupal\Core\Link;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -778,6 +779,44 @@ function socialbase_preprocess_form(&$variables) {
         }
       }
     }
+
+    // Comment edit form.
+    if (\Drupal::routeMatch()->getRouteName() === 'entity.comment.edit_form') {
+      $comment = \Drupal::routeMatch()->getParameter('comment');
+
+      if (is_object($comment)) {
+        // Display comment created date in format 'time ago'.
+        $created_time_ago = \Drupal::service('date.formatter')
+          ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 2));
+        $submitted = t('@time ago', array('@time' => $created_time_ago));
+        $variables['submitted'] = Link::fromTextAndUrl($submitted, $comment->urlInfo('canonical'));
+
+        // Display author information.
+        $account = $comment->getOwner();
+        if ($account) {
+          // Author profile picture.
+          $storage = \Drupal::entityTypeManager()->getStorage('profile');
+          if (!empty($storage)) {
+            $user_profile = $storage->loadByUser($account, 'profile');
+            if ($user_profile) {
+              $content = \Drupal::entityTypeManager()
+                ->getViewBuilder('profile')
+                ->view($user_profile, 'compact');
+              $variables['author_picture'] = $content;
+            }
+          }
+
+          // Author name.
+          $username = array(
+            '#theme' => 'username',
+            '#account' => $account,
+          );
+          $variables['author'] = drupal_render($username);
+        }
+      }
+
+    }
+
   }
 
 }

--- a/public_html/profiles/social/themes/socialbase/socialbase.theme
+++ b/public_html/profiles/social/themes/socialbase/socialbase.theme
@@ -304,7 +304,11 @@ function socialbase_theme_suggestions_form_alter(array &$suggestions, array $var
 
   // Alter comment form
   if ($variables['element']['#id'] == 'comment-form') {
-    $suggestions = array($variables['theme_hook_original'] . '__' . 'comment_form');
+    if(\Drupal::routeMatch()->getRouteName() === 'entity.comment.edit_form'){
+      $suggestions = array($variables['theme_hook_original'] . '__' . 'comment_form_edit');
+    } else {
+      $suggestions = array($variables['theme_hook_original'] . '__' . 'comment_form');
+    }
   }
 
   // Also for the search hero content form on the /search/content.

--- a/public_html/profiles/social/themes/socialbase/templates/comment/comment.html.twig
+++ b/public_html/profiles/social/themes/socialbase/templates/comment/comment.html.twig
@@ -77,7 +77,7 @@
     <div class="media-body">
       <h5 class="media-heading">
         {{ author }}
-      </h5> <br />
+      </h5>
       <small>{{ submitted }}</small>
     </div>
   </div>

--- a/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
+++ b/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
@@ -16,9 +16,9 @@
 <div class="media">
   <div class="media-left">{{ author_picture }}</div>
   <div class="media-body">
-    <h5 class="media-heading">{{ author }}&bullet;<br><small>{{ submitted }}</small></h5>
+    <h5 class="media-heading">{{ author }}&bullet; <small>{{ submitted }}</small></h5>
     <form{{ attributes|without('class') }}>
-      <div class="form-group form-group-inline">
+      <div class="form-group">
         {{ children }}
       </div>
     </form>

--- a/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
+++ b/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
@@ -14,9 +14,9 @@
 #}
 
 <div class="media">
-  <div class="media-left">{{ current_user_picture }}</div>
+  <div class="media-left">{{ author_picture }}</div>
   <div class="media-body">
-    {#<h5 class="media-heading"><a href="my-stream.html">John Johnson </a>&bullet; <small>6 hours ago</small></h5>#}
+    <h5 class="media-heading">{{ author }}&bullet;<br><small>{{ submitted }}</small></h5>
     <form{{ attributes|without('class') }}>
       <div class="form-group form-group-inline">
         {{ children }}

--- a/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
+++ b/public_html/profiles/social/themes/socialbase/templates/form/form--comment-form-edit.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a 'form' element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The child elements of the form.
+ *
+ * @see template_preprocess_form()
+ *
+ * @ingroup themeable
+ */
+#}
+
+<div class="media">
+  <div class="media-left">{{ current_user_picture }}</div>
+  <div class="media-body">
+    {#<h5 class="media-heading"><a href="my-stream.html">John Johnson </a>&bullet; <small>6 hours ago</small></h5>#}
+    <form{{ attributes|without('class') }}>
+      <div class="form-group form-group-inline">
+        {{ children }}
+      </div>
+    </form>
+  </div>
+</div>

--- a/public_html/profiles/social/themes/socialbase/templates/page--comment--edit.html.twig
+++ b/public_html/profiles/social/themes/socialbase/templates/page--comment--edit.html.twig
@@ -1,0 +1,94 @@
+{#
+/**
+ * @file
+ * Bartik's theme implementation to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.highlighted: Items for the highlighted region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.featured_top: Items for the featured top region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.featured_bottom_first: Items for the first featured bottom region.
+ * - page.featured_bottom_second: Items for the second featured bottom region.
+ * - page.featured_bottom_third: Items for the third featured bottom region.
+ * - page.footer_first: Items for the first footer column.
+ * - page.footer_second: Items for the second footer column.
+ * - page.footer_third: Items for the third footer column.
+ * - page.footer_fourth: Items for the fourth footer column.
+ * - page.footer_fifth: Items for the fifth footer column.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<header id="header" role="banner" aria-label="{{ 'Site header'|t}}">
+  {{ page.header }}
+</header>
+
+<main id="content" class="column main-container" role="main">
+
+  {{ page.breadcrumb }}
+
+  <div class="container hero-container">
+    <div class="cover">
+      <h1 class="page-title h2">{{ plain_title }}</h1>
+    </div>
+  </div>
+
+  <a id="main-content" tabindex="-1"></a>
+  <div class="container">
+    <div class="row margin-top-l">
+      {% if page.complementary %}
+        <div role="complementary" class="col-xs-12 col-sm-4 col-sm-last margin-bottom-l">
+          {{ page.complementary }}
+        </div>
+      {% endif %}
+
+      <div class="col-xs-12 col-sm-8">
+        <div class="card">
+          <div class="card-body extra-padding">
+            <div class="media-list">
+              {{ page.content }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</main>
+
+<footer role="contentinfo">
+  {{ page.footer }}
+</footer>


### PR DESCRIPTION
# Changes on reply form
- The button text changed to "Reply"
- The placeholder text chnaged be "Add a reply"
- The "reply" link is not present
- Add new template for reply edit comment
- Remove the BR between name and timestamp (also in Hi-Fi)

# HTT
- [x] Check that reply comment page matches Hi-Fi
- [x] Check that reply edit comment page matches Hi-Fi
- [x] Check that BR between name and timestamp is removed
- [x] Check that button text and placeholder text are correct