### PR TITLE
DS-1512 Time ago improvements (comments, post and activity stream)

### DIFF
--- a/public_html/profiles/social/modules/custom/activity_creator/activity.page.inc
+++ b/public_html/profiles/social/modules/custom/activity_creator/activity.page.inc
@@ -33,9 +33,9 @@ function template_preprocess_activity(array &$variables) {
   // Get the url to the related entity.
   $full_url = $activity->getRelatedEntityUrl();
 
-  // Display comment created date in format 'time ago'.
+  // Display activity created date in format 'time ago'.
   $created_time_ago = \Drupal::service('date.formatter')
-    ->formatTimeDiffSince($activity->getCreatedTime(), array('granularity' => 2, 'return_as_object' => TRUE));
+    ->formatTimeDiffSince($activity->getCreatedTime(), array('granularity' => 1, 'return_as_object' => TRUE));
   $date = t('%time ago', array('%time' => $created_time_ago->getString()));
   if ($full_url == '') {
     $variables['date'] = $date;
@@ -44,6 +44,7 @@ function template_preprocess_activity(array &$variables) {
     $variables['date'] = Link::fromTextAndUrl($date, $full_url);
   }
   $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
+
   // To change user picture settings (e.g. image style), edit the 'compact'
   // view mode on the User entity. Note that the 'compact' view mode might
   // not be configured, so remember to always check the theme setting first.

--- a/public_html/profiles/social/modules/custom/activity_creator/activity.page.inc
+++ b/public_html/profiles/social/modules/custom/activity_creator/activity.page.inc
@@ -35,15 +35,15 @@ function template_preprocess_activity(array &$variables) {
 
   // Display comment created date in format 'time ago'.
   $created_time_ago = \Drupal::service('date.formatter')
-    ->formatTimeDiffSince($activity->getCreatedTime(), array('granularity' => 2));
-  $date = t('%time ago', array('%time' => $created_time_ago));
+    ->formatTimeDiffSince($activity->getCreatedTime(), array('granularity' => 2, 'return_as_object' => TRUE));
+  $date = t('%time ago', array('%time' => $created_time_ago->getString()));
   if ($full_url == '') {
     $variables['date'] = $date;
   }
   else {
     $variables['date'] = Link::fromTextAndUrl($date, $full_url);
   }
-
+  $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
   // To change user picture settings (e.g. image style), edit the 'compact'
   // view mode on the User entity. Note that the 'compact' view mode might
   // not be configured, so remember to always check the theme setting first.

--- a/public_html/profiles/social/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
+++ b/public_html/profiles/social/modules/custom/activity_logger/src/Service/ActivityLoggerFactory.php
@@ -42,6 +42,7 @@ class ActivityLoggerFactory {
 
       // Set the values.
       $new_message['type'] = $message_type;
+      $new_message['created'] = $entity->getCreatedTime();
       $new_message['uid'] = $entity->getOwner()->id();
       $new_message['field_message_context'] = $mt_context;
       $new_message['field_message_destination'] = $destinations;

--- a/public_html/profiles/social/modules/development/social_demo/src/Content/SocialDemoComment.php
+++ b/public_html/profiles/social/modules/development/social_demo/src/Content/SocialDemoComment.php
@@ -145,6 +145,12 @@ class SocialDemoComment implements ContainerInjectionInterface {
         $pid = $parent_comment->id();
       }
 
+      if ($content['created'] > time()) {
+        // Make sure comments are not posted in the future.
+        $content['created'] = time();
+      }
+
+
       // Let's create some nodes.
       $comment = Comment::create([
         'uuid' => $content['uuid'],

--- a/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
+++ b/public_html/profiles/social/modules/social_features/social_comment/social_comment.module
@@ -101,10 +101,11 @@ function social_comment_preprocess_comment(&$variables) {
   $comment = $variables['elements']['#comment'];
   // Display comment created date in format 'time ago'.
   $created_time_ago = \Drupal::service('date.formatter')
-    ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 2));
-  $submitted = t('@time ago', array('@time' => $created_time_ago));
+    ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 1, 'return_as_object' => TRUE));
+  $date = t('%time ago', array('%time' => $created_time_ago->getString()));
 
-  $variables['submitted'] = Link::fromTextAndUrl($submitted, $comment->urlInfo('canonical'));
+  $variables['submitted'] = Link::fromTextAndUrl($date, $comment->urlInfo('canonical'));
+  $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
 
   $account = $comment->getOwner();
   if ($account) {

--- a/public_html/profiles/social/modules/social_features/social_post/post.page.inc
+++ b/public_html/profiles/social/modules/social_features/social_post/post.page.inc
@@ -29,11 +29,13 @@ function template_preprocess_post(array &$variables) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
 
-  // Display comment created date in format 'time ago'.
+  // Display Post created date in format 'time ago'.
   $created_time_ago = \Drupal::service('date.formatter')
-    ->formatTimeDiffSince($post->getCreatedTime(), array('granularity' => 2));
-  $date = t('%time ago', array('%time' => $created_time_ago));
+    ->formatTimeDiffSince($post->getCreatedTime(), array('granularity' => 1, 'return_as_object' => TRUE));
+  $date = t('%time ago', array('%time' => $created_time_ago->getString()));
   $variables['date'] = Link::fromTextAndUrl($date, $post->urlInfo('canonical'));
+  $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
+
 
   // To change user picture settings (e.g. image style), edit the 'compact'
   // view mode on the User entity. Note that the 'compact' view mode might

--- a/public_html/profiles/social/themes/socialbase/socialbase.theme
+++ b/public_html/profiles/social/themes/socialbase/socialbase.theme
@@ -849,9 +849,12 @@ function socialbase_preprocess_form(&$variables) {
       if (is_object($comment)) {
         // Display comment created date in format 'time ago'.
         $created_time_ago = \Drupal::service('date.formatter')
-          ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 2));
-        $submitted = t('@time ago', array('@time' => $created_time_ago));
+          ->formatTimeDiffSince($comment->getCreatedTime(), array('granularity' => 1, 'return_as_object' => TRUE));
+
+        $submitted = t('@time ago', array('@time' => $created_time_ago->getString()));
         $variables['submitted'] = Link::fromTextAndUrl($submitted, $comment->urlInfo('canonical'));
+        $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
+
 
         // Display author information.
         $account = $comment->getOwner();
@@ -889,12 +892,13 @@ function socialbase_preprocess_form(&$variables) {
       $post = entity_load('post', $post_id);
 
       $form['#post_id'] = $post->id();
-      // Display comment created date in format 'time ago'.
+      // Display post created date in format 'time ago'.
       $created_time_ago = \Drupal::service('date.formatter')
-        ->formatTimeDiffSince($post->getCreatedTime(), array('granularity' => 2));
-      $date = t('%time ago', array('%time' => $created_time_ago));
-
+        ->formatTimeDiffSince($post->getCreatedTime(), array('granularity' => 1, 'return_as_object' => TRUE));
+      $date = t('%time ago', array('%time' => $created_time_ago->getString()));
       $variables['date']['#markup'] = $date;
+      $variables['#cache']['max-age'] = $created_time_ago->getMaxAge();
+
 
       // To change user picture settings (e.g. image style), edit the 'compact'
       // view mode on the User entity. Note that the 'compact' view mode might


### PR DESCRIPTION
## HTT

- [x]  Checkout the branch and do a reinstall. Enable caching on your local environment (e.g. change development in production in docker-compose.yml and run docker-compose up -d)
- [x] Check that the demo content is displayed correctly with the timestamps.
- [x] Create a post and check that it has x seconds ago
- [x] Refresh a couple of times and see that the seconds ago add up until it is one minute
- [x] Go to the post detail page and see it is one minute there as well
- [x] Check that nodes and comments in activity stream have there time ago's refreshed as well if you wait a minute.
- [x] Check the code

h2. Solution
It was not clear what exactly went wrong but these following changes will likely fix it:
- Made sure the activity has the same created date as the entity it was created for.
- Enabled correct caching max age for the timestamps (currently they are not updated and always cached)
- Made sure demo content comments are always in the future.
- Changed the granularity to 1 instead of 2 (e.g. 2 minutes and 1 second ago) for performance and usability reasons **Discussed this with Taco that it was ok**

For background information for the solution see:
https://www.drupal.org/node/2500525
