### PR TITLE
Update cweagons/composerpatches to latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "cweagans/composer-patches": "1.5.0",
+        "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
         "goalgorilla/open_social": "dev-8.x-1.x",
         "goalgorilla/open_social_scripts": "dev-master"


### PR DESCRIPTION
Noticed this error in our builds in Travis.

> Deprecation Notice: The callback cweagans\Composer\Patches::postInstall declared at /home/travis/build/goalgorilla/open_social/install/vendor/cweagans/composer-patches/src/Patches.php accepts a Composer\Script\PackageEvent but post-package-install events use a Composer\Installer\PackageEvent instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes in phar:///home/travis/.phpenv/versions/5.6.24/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:317

The latest release https://github.com/cweagans/composer-patches/releases should fix this. So I changed the version constraint in the composer.json to make sure to use the latest release instead.