### PR TITLE
DS-3893 by bramtenhove: Enable coding standards check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   - docker ps -a
 
 script:
+  - docker exec -i social_ci_web bash /var/www/scripts/social/check-coding-standards.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh
   - docker exec -i social_ci_web bash /var/www/scripts/social/check-feature-state.sh social
   - docker exec -i social_ci_web_scripts sh /var/www/scripts/social/unit-tests.sh


### PR DESCRIPTION
## Description
This is a follow-up of https://github.com/goalgorilla/drupal_social/pull/318 and https://github.com/goalgorilla/open_social_scripts/pull/6.
The coding standards check is now ran on Travis CI before any other scripts. It does not *yet* exit with 1 if errors or warnings are found, but this can easily be enabled.

## HTT
- [ ] Check Travis CI build, for example https://travis-ci.org/goalgorilla/drupal_social/builds/253582070, notice the script is run and reports (summarized) about errors and warnings and the file it is located in.