### PR TITLE
DS-4122 - Move front-end libraries to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "8.x-1.x",
+        "goalgorilla/open_social": "dev-8.x-1.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-8.x-1.x",
+        "goalgorilla/open_social": "dev-features/DS-4122-move-libraries",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {
@@ -35,6 +35,19 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "library-fians/waves",
+                "version": "v0.6.4",
+                "type": "drupal-library",
+                "source": {
+                    "url": "https://github.com/fians/Waves",
+                    "type": "git",
+                    "reference": "v0.6.4"
+                }
+            }
         }
     ],
     "scripts": {
@@ -61,6 +74,9 @@
             ],
             "html/themes/contrib/{$name}": [
                 "type:drupal-theme"
+            ],
+            "html/libraries/{$name}": [
+                "type:drupal-library"
             ],
             "scripts/{$name}": [
                 "goalgorilla/open_social_scripts"

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,19 @@
                     "reference": "1.11.4"
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "library-filamentgroup/tablesaw",
+                "version": "2.0.3",
+                "type": "drupal-library",
+                "source": {
+                    "url": "https://github.com/filamentgroup/tablesaw",
+                    "type": "git",
+                    "reference": "2.0.3"
+                }
+            }
         }
     ],
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "type": "package",
             "package": {
                 "name": "library-fians/waves",
-                "version": "v0.7.5",
+                "version": "0.7.5",
                 "type": "drupal-library",
                 "source": {
                     "url": "https://github.com/fians/Waves",

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,8 @@
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
-        "oomphinc/composer-installers-extender": "^1.1",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-feature/DS-4122-move-libraries",
+        "goalgorilla/open_social": "8.x-1.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "cweagans/composer-patches": "^1.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-feature/DS-4122-bower-composer-test",
+        "goalgorilla/open_social": "dev-feature/DS-4122-move-libraries",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
+        "oomphinc/composer-installers-extender": "^1.1",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-feature/DS-4122-move-libraries",
+        "goalgorilla/open_social": "dev-feature/DS-4122-bower-composer-test",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {
@@ -37,43 +38,8 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-            "type": "package",
-            "package": {
-                "name": "library-fians/waves",
-                "version": "0.7.5",
-                "type": "drupal-library",
-                "source": {
-                    "url": "https://github.com/fians/Waves",
-                    "type": "git",
-                    "reference": "v0.7.5"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "library-jonthornton/jquery-timepicker",
-                "version": "1.11.4",
-                "type": "drupal-library",
-                "source": {
-                    "url": "https://github.com/jonthornton/jquery-timepicker",
-                    "type": "git",
-                    "reference": "1.11.4"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "library-filamentgroup/tablesaw",
-                "version": "2.0.3",
-                "type": "drupal-library",
-                "source": {
-                    "url": "https://github.com/filamentgroup/tablesaw",
-                    "type": "git",
-                    "reference": "v2.0.3"
-                }
-            }
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     ],
     "scripts": {
@@ -85,6 +51,10 @@
         ]
     },
     "extra": {
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
         "installer-paths": {
             "html/core": [
                 "drupal/core"
@@ -102,7 +72,9 @@
                 "type:drupal-theme"
             ],
             "html/libraries/{$name}": [
-                "type:drupal-library"
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
             ],
             "scripts/{$name}": [
                 "goalgorilla/open_social_scripts"

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,19 @@
                     "reference": "v0.6.4"
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "library-jonthornton/jquery-timepicker",
+                "version": "1.11.4",
+                "type": "drupal-library",
+                "source": {
+                    "url": "https://github.com/jonthornton/jquery-timepicker",
+                    "type": "git",
+                    "reference": "1.11.4"
+                }
+            }
         }
     ],
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-features/DS-4122-move-libraries",
+        "goalgorilla/open_social": "dev-feature/DS-4122-move-libraries",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
                 "source": {
                     "url": "https://github.com/filamentgroup/tablesaw",
                     "type": "git",
-                    "reference": "2.0.3"
+                    "reference": "v2.0.3"
                 }
             }
         }


### PR DESCRIPTION
## Description

In order to be able to require front-end libraries via composer, we will need to update the root composer.json file. This PR is basically preparation for the main changes done in the open_social repo.

This change is based on what Acquia Lightning did:
- https://lightning.acquia.com/blog/round-your-front-end-javascript-libraries-composer
- https://github.com/acquia/lightning/releases/tag/2.1.7

**Updates done:**
- Adding asset-packagist repo
- Add installer types
- Set a path for the front-end libraries

## How to test

Make sure your composer is up to date! We require at least version **1.5.0**, you can update by running `composer self-update`.

- [x] Do an composer install/update, see that nothing breaks
- [x] Reference `dev-feature/DS-4122-move-libraries` for the `open_social` package
- [x] Do a composer install/update, see that some front-end packages are now installed in html/libraries