### PR TITLE
Add the security-advisories package to fail on composer updates that try to install insecure packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "roave/security-advisories": "dev-master",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",


### PR DESCRIPTION
## Description

A very easy way to check for dependencies with known vulnerabilities is to use https://github.com/Roave/SecurityAdvisories. This is actually suggested by my PHPStorm instance.

Example:
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for roave/security-advisories dev-master -> satisfiable by roave/security-advisories[dev-master].
    - roave/security-advisories dev-master conflicts with zendframework/zendframework[2.3.1].
    - Installation request for zendframework/zendframework 2.3.1 -> satisfiable by zendframework/zendframework[2.3.1].

```

## How to test

- [ ] Add a dependency with known vulnerabilities to your require list, e.g. `zendframework/zendframework:2.3.1`
- [ ] Notice that you can do a composer update due to a conflict between zendframework and security-advisories