### PR TITLE
Update version of "The PHP Unit Testing framework" package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpmd/phpmd": "@stable",
         "pdepend/pdepend": "2.1.0",
         "sebastian/phpcpd": "*",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.36",
         "drupal/console":"1.1"
     },
     "repositories": [


### PR DESCRIPTION
## Description
```
Problem 1
    - Installation request for goalgorilla/open_social dev-feature/DS-1382-language#c942e239eac0c7c812045cbf5e5bb278b0d002c0 -> satisfiable by goalgorilla/open_social[dev-feature/DS-1382-language].
    - goalgorilla/open_social dev-feature/DS-1382-language requires drupal/core 8.4.4 -> satisfiable by drupal/core[8.4.4].
    - Conclusion: remove phpunit/phpunit 4.8.24
    - drupal/core 8.4.4 requires symfony/validator ~3.2.8 -> satisfiable by symfony/validator[3.2.x-dev, v3.2.10, v3.2.11, v3.2.12, v3.2.13, v3.2.14, v3.2.8, v3.2.9].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[3.2.x-dev].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.10].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.11].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.12].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.13].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.14].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.8].
    - phpunit/phpunit 4.8.24 conflicts with symfony/validator[v3.2.9].
    - Installation request for phpunit/phpunit (installed at 4.8.24, required as ^4.8) -> satisfiable by phpunit/phpunit[4.8.24].
```
You can see this problem [here](https://travis-ci.org/goalgorilla/open_social/jobs/339007674).