### PR TITLE
DS-4945 Add tracker to Travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-feature/DS-4945-accessibility",
-        "goalgorilla/open_social_scripts": "dev-feature/DS-4945-accessibility"
+        "goalgorilla/open_social": "dev-8.x-1.x",
+        "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {
         "jcalderonzumba/gastonjs": "~1.0.2",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-8.x-1.x",
-        "goalgorilla/open_social_scripts": "dev-master"
+        "goalgorilla/open_social": "dev-feature/DS-4945-accessibility",
+        "goalgorilla/open_social_scripts": "dev-feature/DS-4945-accessibility"
     },
     "require-dev": {
         "jcalderonzumba/gastonjs": "~1.0.2",
@@ -95,14 +95,6 @@
                 "type:drupal-drush"
             ]
         },
-        "enable-patching": true,
-        "patches": {
-            "goalgorilla/open_social": {
-                "Update Travis": "../open_social.patch"
-            },
-            "goalgorilla/open_social_scripts": {
-                "Create script for checking accessibility": "../open_social_scripts.patch"
-            }
-        }
+        "enable-patching": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "pdepend/pdepend": "2.1.0",
         "sebastian/phpcpd": "*",
         "phpunit/phpunit": "^4.8",
-        "drupal/console":"1.1"
+        "drupal/console":"1.1",
+        "squizlabs/html_codesniffer": "*"
     },
     "repositories": [
         {
@@ -39,6 +40,18 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "squizlabs/html_codesniffer",
+                "version": "1.0.0",
+                "source": {
+                    "url": "https://github.com/squizlabs/HTML_CodeSniffer.git",
+                    "type": "git",
+                    "reference": "master"
+                }
+            }
         }
     ],
     "scripts": {
@@ -82,6 +95,14 @@
                 "type:drupal-drush"
             ]
         },
-        "enable-patching": true
+        "enable-patching": true,
+        "patches": {
+            "goalgorilla/open_social": {
+                "Update Travis": "../open_social.patch"
+            },
+            "goalgorilla/open_social_scripts": {
+                "Create script for checking accessibility": "../open_social_scripts.patch"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem
Do not check accessibility when building environment via Travis.

## Solution
Add depend on package for checking accessibility via a shell script.

## Issue tracker
- https://jira.goalgorilla.com/browse/DS-4945

## HTT
- [x] Travis doing five steps without checking accessibility
- [x] Checkout to this branch
- [x] Add the sixth step for checking accessibility