### PR TITLE
Update composer.json to use 8.x-2.x as base branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_install:
   - docker --version
   - docker-compose --version
   - phpenv config-rm xdebug.ini
-  - composer install --memory=2G --prefer-dist --no-interaction
+  - echo "memory_limit=3072M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - composer install --prefer-dist --no-interaction
   - sudo rm /usr/local/bin/docker-compose || true
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - docker --version
   - docker-compose --version
   - phpenv config-rm xdebug.ini
-  - composer install --prefer-dist --no-interaction
+  - composer install --memory=2G --prefer-dist --no-interaction
   - sudo rm /usr/local/bin/docker-compose || true
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-8.x-1.x",
+        "goalgorilla/open_social": "dev-8.x-2.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
As we want to move to 2.x it's a good idea also to use 8.x-2.x branch as default when using this repo.