### PR TITLE
Add support for Blackfire profiling to the Open Social docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     links:
      - db
      - mailcatcher
+     - blackfire
     environment:
      - VIRTUAL_HOST=social.dev
      - DRUPAL_SETTINGS=development
@@ -24,7 +25,7 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     ports:
-      - "3307:3306"
+      - "3306"
     network_mode: "bridge"
     container_name: social_db
     command: mysqld --max_allowed_packet=16M
@@ -66,6 +67,17 @@ services:
      - DRUPAL_SETTINGS=development
     network_mode: "bridge"
     container_name: social_behat
+
+  blackfire:
+    image: blackfire/blackfire
+    environment:
+        # Exposes the host BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables.
+        # Find the values for these on https://blackfire.io/docs/integrations/docker while logged in.
+        # For ease of use on multiple project copy those export statements to ~/.bash_profile.
+        - BLACKFIRE_SERVER_ID
+        - BLACKFIRE_SERVER_TOKEN
+    network_mode: "bridge"
+    container_name: social_blackfire
 
   cron:
     image: goalgorilla/open_social_docker:cron


### PR DESCRIPTION
This commit adds the blackfire docker image as a container in the
docker-compose file and links it to the web container. This makes
it possible to use the Chrome Blackfire plugin to analyse any
Open Social website.

For this commit to work properly it is required that the Blackfire
probe is added to the open_social_docker:dev image.

For more info on how to use Blackfire in Docker and to find out
what keys you should add to your .bash_profile go to
https://blackfire.io/docs/integrations/docker

This PR requires https://github.com/goalgorilla/open_social_docker/pull/10 to work