### PR TITLE
speedup composer drastically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "phpunit/phpunit": "^6.5",
         "phpunit/php-timer": "^1.0.9",
         "drupal/console": "@stable",
+        "zaporylie/composer-drupal-optimizations": "^1.0",
         "squizlabs/html_codesniffer": "*"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,13 @@
         "behat/mink-extension": "*",
         "behat/mink-goutte-driver": "*",
         "behat/mink-selenium2-driver": "*",
-        "drupal/coder": "dev-8.x-2.x",
+        "drupal/coder": "^8.3",
         "drupal/drupal-extension": "^3.4",
         "phpmd/phpmd": "@stable",
-        "pdepend/pdepend": "2.1.0",
-        "sebastian/phpcpd": "*",
+        "sebastian/phpcpd": "@stable",
         "phpunit/phpunit": "^6.5",
         "phpunit/php-timer": "^1.0.9",
-        "drupal/console":"1.1",
+        "drupal/console": "@stable",
         "squizlabs/html_codesniffer": "*"
     },
     "repositories": [


### PR DESCRIPTION
## Description:
Added `zaporylie/composer-drupal-optimizations` here. This drastically lowers the amount of memory used by composer. 

I did this on branch: `feature/3012256`

## Results
**without the plugin:**
`[423.4MB/56.11s] Memory usage: 423.39MB (peak: 1594MB), time: 56.11s`
**wit the plugin:**
`[319.6MB/27.44s] Memory usage: 319.57MB (peak: 560.23MB), time: 27.44s`

Updated some versions of coder and php too in here