### PR TITLE
Update drush to stable version 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
-        "drush/drush": "8.*@stable",
+        "drush/drush": "9.*@stable",
         "goalgorilla/open_social": "dev-8.x-4.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },


### PR DESCRIPTION
Only change needed was this composer.json. 

The changes we talked about in the Docker file are already done a while back:
https://github.com/goalgorilla/open_social_docker/blob/master/Dockerfile

The drush executable is not installed anymore in the container, but a symlink to /var/www/vendor/bin/drush, which is good