### PR TITLE
Revert "Update drush to stable version 9"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
-        "drush/drush": "9.*@stable",
+        "drush/drush": "8.*@stable",
         "goalgorilla/open_social": "dev-8.x-4.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },


### PR DESCRIPTION
Reverts goalgorilla/drupal_social#340

The Drush 9 update has some consequences for drush commands that were overlooked. Since this change may have implications for production websites we're reverting until we can investigate.