### PR TITLE
Add mglaman/drupal-check and blackfire/php-sdk and update to 8.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,15 @@
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-8.x-7.x",
+        "goalgorilla/open_social": "dev-8.x-8.x",
         "goalgorilla/open_social_scripts": "dev-master",
         "drupal/social_course": "dev-8.x-2.x",
         "drupal/social_geolocation": "dev-8.x-1.x",
         "goalgorilla/social_json_api": "dev-8.x-1.x",
         "drupal/social_kpi_lite": "dev-8.x-1.x",
         "goalgorilla/social_pwa": "dev-8.x-1.x",
-        "drupal/redis": "^1.2"
+        "drupal/redis": "^1.2",
+        "blackfire/php-sdk": "^1.19"
     },
     "require-dev": {
         "jcalderonzumba/gastonjs": "~1.0.2",
@@ -39,7 +40,8 @@
         "phpunit/php-timer": "^1.0.9",
         "drupal/console": "@stable",
         "zaporylie/composer-drupal-optimizations": "^1.0",
-        "squizlabs/html_codesniffer": "*"
+        "squizlabs/html_codesniffer": "*",
+        "mglaman/drupal-check": "^1.0"
     },
     "repositories": {
         "0": {
@@ -130,6 +132,9 @@
         },
         "enable-patching": true,
         "patches": {
+            "drupal/like_dislike": {
+                "Add support for webprofiler": "patches/like-dislike-fix-webprofiler.patch"
+            },
             "squizlabs/html_codesniffer": {
                 "Translatings does not work": "patches/DS-5443-accessibility.patch"
             }

--- a/patches/like-dislike-fix-webprofiler.patch
+++ b/patches/like-dislike-fix-webprofiler.patch
@@ -1,0 +1,22 @@
+diff --git a/src/LikeDislikePermissions.php b/src/LikeDislikePermissions.php
+index c197045..9caeeef 100644
+--- a/src/LikeDislikePermissions.php
++++ b/src/LikeDislikePermissions.php
+@@ -5,7 +5,7 @@ namespace Drupal\like_and_dislike;
+ use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+-use Drupal\Core\Entity\EntityTypeManager;
++use Drupal\Core\Entity\EntityTypeManagerInterface;
+ use Drupal\Core\StringTranslation\StringTranslationTrait;
+ use Drupal\votingapi\Entity\VoteType;
+ use Symfony\Component\DependencyInjection\ContainerInterface;
+@@ -48,7 +48,7 @@ class LikeDislikePermissions implements ContainerInjectionInterface {
+    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $bundle_info_service
+    *   The bundle info service.
+    */
+-  public function __construct(EntityTypeManager $entity_type_manager, ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $bundle_info_service) {
++  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $bundle_info_service) {
+     $this->entityTypeManager = $entity_type_manager;
+     $this->configFactory = $config_factory;
+     $this->bundleInfoService = $bundle_info_service;


### PR DESCRIPTION
Two small things:
- Update to 8.x-8.x
- Add blackfire/php-sdk

More importantly added [static code analyser](https://github.com/mglaman/drupal-check). It can be used as follows after installation:
`/var/www/vendor/bin/drupal-check /var/www/html/profiles/contrib/social`

It will give you a result like this:
```
root@0f4d2f415f7d:/var/www/html# ../vendor/bin/drupal-check profiles/contrib/social/
 764/764 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------- 
  Line   modules/custom/activity_creator/activity_creator.module            
 ------ ------------------------------------------------------------------- 
  306    Call to deprecated function entity_delete_multiple():              
         as of Drupal 8.0.x, will be removed before Drupal 9.0.0. Use       
         the entity storage's delete() method to delete multiple entities:  
 ------ ------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/custom/activity_creator/src/ActivityAccessControlHandler.php  
 ------ ---------------------------------------------------------------------- 
  75     Call to deprecated function entity_load():                            
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the         
         entity type storage's load() method.                                  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------ 
  Line   modules/custom/activity_creator/src/ActivityListBuilder.php                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------ 
  16     Usage of deprecated trait Drupal\Core\Routing\LinkGeneratorTrait in class Drupal\activity_creator\ActivityListBuilder:  
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                                
         Use \Drupal\Core\Link instead.                                                                                          
  33     Call to deprecated method l() of class Drupal\activity_creator\ActivityListBuilder:                                     
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                                
         Use \Drupal\Core\Link instead.                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------ 
  Line   modules/custom/activity_creator/src/ActivityNotifications.php     
 ------ ------------------------------------------------------------------ 
  48     Call to deprecated function entity_load_multiple():               
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the  
         entity type storage's loadMultiple() method.                      
 ------ ------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------- 
  Line   modules/custom/activity_creator/src/Entity/Activity.php                           
 ------ ---------------------------------------------------------------------------------- 
  233    Call to deprecated function entity_load():                                        
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the                     
         entity type storage's load() method.                                              
  240    Call to deprecated function entity_load():                                        
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the                     
         entity type storage's load() method.                                              
  269    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:  
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                           
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                         
 ------ ---------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/custom/activity_creator/src/Form/ActivityForm.php             
 ------ ---------------------------------------------------------------------- 
  33     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  39     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------- 
  Line   modules/custom/activity_viewer/src/Plugin/Field/FieldFormatter/ActivityEntityReferenceFormatter.php  
 ------ ----------------------------------------------------------------------------------------------------- 
  47     Call to deprecated method url() of class Drupal\Core\Entity\EntityInterface:                         
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                              
         Please use toUrl() instead.                                                                          
 ------ ----------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------ 
  Line   modules/custom/activity_viewer/src/Plugin/views/argument/ActivityGroupArgument.php  
 ------ ------------------------------------------------------------------------------------ 
  29     Call to deprecated function db_or():                                                
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                         
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                    
         conjunction: new Condition('OR');                                                   
 ------ ------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------- 
  Line   modules/custom/activity_viewer/src/Plugin/views/argument/ActivityProfileArgument.php  
 ------ -------------------------------------------------------------------------------------- 
  29     Call to deprecated function db_or():                                                  
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                           
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                      
         conjunction: new Condition('OR');                                                     
  36     Call to deprecated function db_and():                                                 
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                           
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                     
         conjunction: new Condition('AND');                                                    
 ------ -------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------- 
  Line   modules/custom/activity_viewer/src/Plugin/views/filter/ActivityFilterPersonalisedHomepage.php  
 ------ ----------------------------------------------------------------------------------------------- 
  42     Call to deprecated function social_group_get_all_group_members():                              
         in Open Social 4.2 and will be removed in one of the next major                                
         updates.                                                                                       
         This function is moved to the service social_group.helper_service, use                         
         getAllGroupsForUser() instead.                                                                 
  98     Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  99     Call to deprecated function db_or():                                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                               
         conjunction: new Condition('OR');                                                              
  102    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  105    Call to deprecated function db_or():                                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                               
         conjunction: new Condition('OR');                                                              
  108    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  123    Call to deprecated function db_or():                                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                               
         conjunction: new Condition('OR');                                                              
  136    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  144    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  160    Call to deprecated function db_or():                                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                               
         conjunction: new Condition('OR');                                                              
  173    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
  179    Call to deprecated function db_and():                                                          
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                                    
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                              
         conjunction: new Condition('AND');                                                             
 ------ ----------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------- 
  Line   modules/custom/activity_viewer/src/Plugin/views/filter/ActivityPostVisibilityAccess.php  
 ------ ----------------------------------------------------------------------------------------- 
  44     Call to deprecated function social_group_get_all_group_members():                        
         in Open Social 4.2 and will be removed in one of the next major                          
         updates.                                                                                 
         This function is moved to the service social_group.helper_service, use                   
         getAllGroupsForUser() instead.                                                           
  102    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  103    Call to deprecated function db_or():                                                     
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                         
         conjunction: new Condition('OR');                                                        
  106    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  109    Call to deprecated function db_or():                                                     
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                         
         conjunction: new Condition('OR');                                                        
  113    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  130    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  138    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  153    Call to deprecated function db_or():                                                     
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                         
         conjunction: new Condition('OR');                                                        
  166    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  172    Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
 ------ ----------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/custom/download_count/download_count.install                  
 ------ ---------------------------------------------------------------------- 
  89     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/custom/download_count/download_count.module                                
 ------ ----------------------------------------------------------------------------------- 
  51     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
  53     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
 ------ ----------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   modules/custom/download_count/src/Plugin/Field/FieldFormatter/FieldDownloadCount.php  
 ------ -------------------------------------------------------------------------------------- 
  94     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:     
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                          
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                     
  95     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:     
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                          
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                     
 ------ -------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------ 
  Line   modules/custom/entity_access_by_field/src/EntityAccessByFieldPermissions.php  
 ------ ------------------------------------------------------------------------------ 
  17     Usage of deprecated trait Drupal\Core\Routing\UrlGeneratorTrait in class      
         Drupal\entity_access_by_field\EntityAccessByFieldPermissions:                 
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                      
         Use \Drupal\Core\Url instead.                                                 
 ------ ------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/custom/entity_access_by_field/tests/src/Unit/EntityAccessTest.php                                                          
 ------ ----------------------------------------------------------------------------------------------------------------------------------- 
         Class Drupal\entity_access_by_field\Tests\EntityAccessTest was not found while trying to analyse it - autoloading is probably not  
         configured properly.                                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/custom/mentions/src/EventSubscriber/MentionsDelete.php            
 ------ -------------------------------------------------------------------------- 
  31     Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
 ------ -------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/custom/mentions/src/EventSubscriber/MentionsInsert.php            
 ------ -------------------------------------------------------------------------- 
  30     Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
 ------ -------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/custom/mentions/src/EventSubscriber/MentionsUpdate.php            
 ------ -------------------------------------------------------------------------- 
  31     Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
 ------ -------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_extra/social_auth_extra.module                          
 ------ ----------------------------------------------------------------------------------- 
  48     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
  233    Call to deprecated function drupal_set_message():                                  
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                           
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.               
  238    Call to deprecated function drupal_set_message():                                  
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                           
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.               
  268    Call to deprecated function drupal_set_message():                                  
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                           
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.               
 ------ ----------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/custom/social_auth_extra/src/Form/AuthUnlinkForm.php          
 ------ ---------------------------------------------------------------------- 
  90     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  96     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------- 
  Line   modules/custom/social_auth_extra/src/UserManager.php            
 ------ ---------------------------------------------------------------- 
  139    Call to deprecated function file_prepare_directory():           
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.           
         Use \Drupal\Core\File\FileSystemInterface::prepareDirectory().  
 ------ ---------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_facebook/src/Controller/FacebookAuthController.php  
 ------ ------------------------------------------------------------------------------- 
  112    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  168    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  185    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  207    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  214    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  235    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  243    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
 ------ ------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_facebook/src/Controller/FacebookLinkController.php  
 ------ ------------------------------------------------------------------------------- 
  76     Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  86     Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  102    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  114    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  132    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  141    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
 ------ ------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_google/src/Controller/GoogleAuthController.php  
 ------ --------------------------------------------------------------------------- 
  112    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  165    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  183    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  205    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  212    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  233    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  241    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
 ------ --------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_google/src/Controller/GoogleLinkController.php  
 ------ --------------------------------------------------------------------------- 
  76     Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  86     Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  102    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  114    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  132    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
  141    Call to deprecated function drupal_set_message():                          
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                   
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.       
 ------ --------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_linkedin/src/Controller/LinkedInAuthController.php  
 ------ ------------------------------------------------------------------------------- 
  112    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  165    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  183    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  205    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  212    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  233    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  241    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
 ------ ------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_linkedin/src/Controller/LinkedInLinkController.php  
 ------ ------------------------------------------------------------------------------- 
  76     Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  86     Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  102    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  114    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  132    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
  141    Call to deprecated function drupal_set_message():                              
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                       
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.           
 ------ ------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_twitter/src/Controller/TwitterAuthController.php  
 ------ ----------------------------------------------------------------------------- 
  139    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  144    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  192    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  210    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  236    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  243    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  267    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  290    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
 ------ ----------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/custom/social_auth_twitter/src/Controller/TwitterLinkController.php  
 ------ ----------------------------------------------------------------------------- 
  81     Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  105    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  121    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  133    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  151    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
  160    Call to deprecated function drupal_set_message():                            
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                     
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.         
 ------ ----------------------------------------------------------------------------- 

 ------ ------------------------------------------------------- 
  Line   modules/custom/social_demo/src/DemoFile.php            
 ------ ------------------------------------------------------- 
  82     Call to deprecated function file_unmanaged_copy():     
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.  
         Use \Drupal\Core\File\FileSystemInterface::copy().     
 ------ ------------------------------------------------------- 

 ------ ---------------------------------------------------------------- 
  Line   modules/custom/social_demo/src/DemoSystem.php                   
 ------ ---------------------------------------------------------------- 
  182    Call to deprecated function file_prepare_directory():           
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.           
         Use \Drupal\Core\File\FileSystemInterface::prepareDirectory().  
  214    Call to deprecated function drupal_basename():                  
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.        
         Use \Drupal\Core\File\FileSystem::basename().                   
 ------ ---------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/custom/social_file_private/social_file_private.install            
 ------ -------------------------------------------------------------------------- 
  37     Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
  38     Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
 ------ -------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   modules/custom/social_font/src/FontListBuilder.php                                                             
 ------ --------------------------------------------------------------------------------------------------------------- 
  17     Usage of deprecated trait Drupal\Core\Routing\LinkGeneratorTrait in class Drupal\social_font\FontListBuilder:  
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                       
         Use \Drupal\Core\Link instead.                                                                                 
  34     Call to deprecated method l() of class Drupal\social_font\FontListBuilder:                                     
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                       
         Use \Drupal\Core\Link instead.                                                                                 
 ------ --------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/custom/social_font/src/Form/FontForm.php                      
 ------ ---------------------------------------------------------------------- 
  35     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  41     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------ 
  Line   modules/custom/social_language/modules/social_content_translation/social_content_translation.install  
 ------ ------------------------------------------------------------------------------------------------------ 
  73     Call to deprecated method entityManager() of class Drupal:                                            
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                              
         Use \Drupal::entityTypeManager() instead in most cases. If the needed                                 
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the                              
         deprecated \Drupal\Core\Entity\EntityManager to find the                                              
         correct interface or service.                                                                         
 ------ ------------------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/custom/template_suggestions_extra/template_suggestions_extra.module  
 ------ ----------------------------------------------------------------------------- 
  33     Call to deprecated function node_load():                                     
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use                 
         \Drupal\node\Entity\Node::load().                                            
 ------ ----------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_comment/src/Controller/SocialCommentController.php  
 ------ ----------------------------------------------------------------------------------- 
  31     Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:   
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                            
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                          
  84     Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:   
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                            
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                          
 ------ ----------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------- 
  Line   modules/social_features/social_comment/src/Form/SocialCommentAdminOverview.php  
 ------ -------------------------------------------------------------------------------- 
  273    Call to deprecated function drupal_set_message():                               
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                        
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.            
 ------ -------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_core/social_core.install                                                       
 ------ -------------------------------------------------------------------------------------------------------------- 
  159    Call to deprecated function file_unmanaged_copy():                                                            
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.                                                         
         Use \Drupal\Core\File\FileSystemInterface::copy().                                                            
  497    Call to deprecated function drupal_set_message():                                                             
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                                      
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                          
  500    Call to deprecated function drupal_set_message():                                                             
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                                      
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                          
  598    Call to deprecated function drupal_set_message():                                                             
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                                      
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                          
  601    Call to deprecated function drupal_set_message():                                                             
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                                      
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                          
  692    Call to deprecated method applyUpdates() of class Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface:  
         in Drupal 8.7.0, will be removed before Drupal 9.0.0. Use                                                     
         \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface::getChangeList()                                   
         and execute each entity type and field storage update manually instead.                                       
  726    Call to deprecated method fieldSetNoDefault() of class Drupal\Core\Database\Schema:                           
         as of Drupal 8.7.x, will be removed in Drupal 9.0.0. Instead,                                                 
         call ::changeField() passing a full field specification.                                                      
  727    Call to deprecated method fieldSetNoDefault() of class Drupal\Core\Database\Schema:                           
         as of Drupal 8.7.x, will be removed in Drupal 9.0.0. Instead,                                                 
         call ::changeField() passing a full field specification.                                                      
 ------ -------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   modules/social_features/social_core/social_core.module                            
 ------ ---------------------------------------------------------------------------------- 
  143    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:  
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                           
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                         
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_core/src/Controller/EntityAutocompleteController.php  
 ------ ------------------------------------------------------------------------------------- 
  29     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:    
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                            
         mb_strtolower() instead.                                                             
 ------ ------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_core/src/Plugin/Field/FieldFormatter/CommentNodeFormatter.php  
 ------ ---------------------------------------------------------------------------------------------- 
  121    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:              
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                       
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                                     
  198    Call to deprecated function db_select():                                                      
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get                             
         a database connection injected into your service from the container and                       
         call select() on it. For example,                                                             
  235    Call to deprecated function entity_load_multiple():                                           
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the                              
         entity type storage's loadMultiple() method.                                                  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------- 
  Line   modules/social_features/social_embed/social_embed.module  
 ------ ---------------------------------------------------------- 
  19     Call to deprecated function file_unmanaged_copy():        
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.     
         Use \Drupal\Core\File\FileSystemInterface::copy().        
 ------ ---------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/modules/social_event_an_enroll/social_event_an_enroll.module  
 ------ --------------------------------------------------------------------------------------------------- 
  251    Call to deprecated function drupal_set_message():                                                  
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                           
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                               
 ------ --------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollActionForm.php  
 ------ ---------------------------------------------------------------------------------------------------------- 
  137    Call to deprecated function drupal_set_message():                                                         
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                                  
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                      
 ------ ---------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/modules/social_event_an_enroll/src/Form/EventAnEnrollForm.php  
 ------ ---------------------------------------------------------------------------------------------------- 
  136    Call to deprecated function drupal_set_message():                                                   
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                            
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                
  150    Call to deprecated function drupal_set_message():                                                   
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                            
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                
 ------ ---------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/modules/social_event_type/social_event_type.module  
 ------ ----------------------------------------------------------------------------------------- 
  70     Call to deprecated method link() of class Drupal\Core\Entity\EntityBase:                 
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                  
         Use \Drupal\Core\EntityInterface::toLink()->toString() instead.                          
 ------ ----------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/src/EventEnrollmentListBuilder.php                                                    
 ------ --------------------------------------------------------------------------------------------------------------------------- 
  16     Usage of deprecated trait Drupal\Core\Routing\LinkGeneratorTrait in class Drupal\social_event\EventEnrollmentListBuilder:  
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                                   
         Use \Drupal\Core\Link instead.                                                                                             
  33     Call to deprecated method l() of class Drupal\social_event\EventEnrollmentListBuilder:                                     
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                                   
         Use \Drupal\Core\Link instead.                                                                                             
 ------ --------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_event/src/Form/EnrollActionForm.php    
 ------ ---------------------------------------------------------------------- 
  314    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   modules/social_features/social_event/src/Form/EventEnrollmentForm.php  
 ------ ----------------------------------------------------------------------- 
  34     Call to deprecated function drupal_set_message():                      
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.               
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.   
  40     Call to deprecated function drupal_set_message():                      
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.               
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.   
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/src/Plugin/Block/EnrollActionBlock.php  
 ------ ----------------------------------------------------------------------------- 
  86     Call to deprecated function node_load():                                     
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use                 
         \Drupal\node\Entity\Node::load().                                            
 ------ ----------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_event/src/Plugin/views/filter/EventEnrolledOrCreated.php  
 ------ ----------------------------------------------------------------------------------------- 
  79     Call to deprecated function db_or():                                                     
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                         
         conjunction: new Condition('OR');                                                        
  82     Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
  88     Call to deprecated function db_and():                                                    
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                              
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                        
         conjunction: new Condition('AND');                                                       
 ------ ----------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------- 
  Line   modules/social_features/social_follow_content/social_follow_content.module  
 ------ ---------------------------------------------------------------------------- 
  59     Call to deprecated function drupal_set_message():                           
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                    
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.        
  124    Call to deprecated function drupal_set_message():                           
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                    
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.        
 ------ ---------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/social_features/social_group/social_group.install                 
 ------ -------------------------------------------------------------------------- 
  248    Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
  286    Call to deprecated function db_table_exists():                            
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get         
         a database connection injected into your service from the container, get  
         its schema driver, and call tableExists() on it. For example,             
  287    Call to deprecated function db_drop_table():                              
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get         
         a database connection injected into your service from the container, get  
         its schema driver, and call dropTable() on it. For example,               
 ------ -------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_group/social_group.module              
 ------ ---------------------------------------------------------------------- 
  719    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_group/social_group.tokens.inc                       
 ------ ----------------------------------------------------------------------------------- 
  95     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
 ------ ----------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_group/src/Controller/DeleteGroup.php   
 ------ ---------------------------------------------------------------------- 
  50     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  55     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_group/src/Plugin/Field/FieldWidget/SocialGroupSelectorWidget.php  
 ------ ------------------------------------------------------------------------------------------------- 
  253    Call to deprecated function drupal_set_message():                                                
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                         
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                             
 ------ ------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_like/social_like.tokens.inc                         
 ------ ----------------------------------------------------------------------------------- 
  76     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
  82     Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
  115    Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_mentions/social_mentions.tokens.inc                 
 ------ ----------------------------------------------------------------------------------- 
  129    Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
  138    Call to deprecated method strtolower() of class Drupal\Component\Utility\Unicode:  
         in Drupal 8.6.0, will be removed before Drupal 9.0.0. Use                          
         mb_strtolower() instead.                                                           
 ------ ----------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_post/social_post.admin.inc             
 ------ ---------------------------------------------------------------------- 
  60     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  130    Call to deprecated method l() of class Drupal:                        
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Link instead.                                        
         Example:                                                              
  161    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  164    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  171    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   modules/social_features/social_post/social_post.module             
 ------ ------------------------------------------------------------------- 
  337    Call to deprecated function entity_delete_multiple():              
         as of Drupal 8.0.x, will be removed before Drupal 9.0.0. Use       
         the entity storage's delete() method to delete multiple entities:  
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Controller/PostCommentController.php               
 ------ ------------------------------------------------------------------------------------------- 
  25     Call to deprecated method entityManager() of class Drupal\Core\Controller\ControllerBase:  
         in Drupal 8.0.0, will be removed before Drupal 9.0.0.                                      
         Most of the time static::entityTypeManager() is supposed to be used                        
         instead.                                                                                   
  35     Call to deprecated function entity_load():                                                 
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the                              
         entity type storage's load() method.                                                       
  41     Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:           
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                    
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                                  
 ------ ------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Form/PostForm.php             
 ------ ---------------------------------------------------------------------- 
  269    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  275    Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Form/PostTypeDeleteForm.php   
 ------ ---------------------------------------------------------------------- 
  41     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Form/PostTypeForm.php         
 ------ ---------------------------------------------------------------------- 
  54     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
  60     Call to deprecated function drupal_set_message():                     
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------ 
  Line   modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostActivityFormatter.php  
 ------ ------------------------------------------------------------------------------------------------------ 
  32     Call to deprecated function db_select():                                                              
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get                                     
         a database connection injected into your service from the container and                               
         call select() on it. For example,                                                                     
  61     Call to deprecated function entity_load_multiple():                                                   
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the                                      
         entity type storage's loadMultiple() method.                                                          
 ------ ------------------------------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Plugin/Field/FieldFormatter/CommentPostFormatter.php  
 ------ ---------------------------------------------------------------------------------------------- 
  96     Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:              
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                       
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                                     
  118    Call to deprecated function entity_load():                                                    
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the                                 
         entity type storage's load() method.                                                          
  192    Call to deprecated function db_select():                                                      
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get                             
         a database connection injected into your service from the container and                       
         call select() on it. For example,                                                             
  230    Call to deprecated function entity_load_multiple():                                           
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the                              
         entity type storage's loadMultiple() method.                                                  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Plugin/views/area/SocialPostPostForm.php  
 ------ ---------------------------------------------------------------------------------- 
  156    Call to deprecated method entityManager() of class Drupal:                        
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                          
         Use \Drupal::entityTypeManager() instead in most cases. If the needed             
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the          
         deprecated \Drupal\Core\Entity\EntityManager to find the                          
         correct interface or service.                                                     
 ------ ---------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Plugin/views/filter/PostAccountStream.php  
 ------ ----------------------------------------------------------------------------------- 
  51     Call to deprecated function db_or():                                               
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                        
         a \Drupal\Core\Database\Query\Condition object, specifying an OR                   
         conjunction: new Condition('OR');                                                  
  54     Call to deprecated function db_and():                                              
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                        
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                  
         conjunction: new Condition('AND');                                                 
  60     Call to deprecated function db_and():                                              
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                        
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                  
         conjunction: new Condition('AND');                                                 
 ------ ----------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Plugin/views/filter/PostGroupStream.php  
 ------ --------------------------------------------------------------------------------- 
  52     Call to deprecated function db_and():                                            
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                      
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                
         conjunction: new Condition('AND');                                               
 ------ --------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/Plugin/views/filter/PostVisibilityAccess.php  
 ------ -------------------------------------------------------------------------------------- 
  47     Call to deprecated function db_and():                                                 
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Create                           
         a \Drupal\Core\Database\Query\Condition object, specifying an AND                     
         conjunction: new Condition('AND');                                                    
 ------ -------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/PostAccessControlHandler.php  
 ------ ---------------------------------------------------------------------- 
  72     Call to deprecated function entity_load():                            
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the         
         entity type storage's load() method.                                  
  107    Call to deprecated function entity_load():                            
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the         
         entity type storage's load() method.                                  
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/PostListBuilder.php                                                    
 ------ --------------------------------------------------------------------------------------------------------------- 
  15     Usage of deprecated trait Drupal\Core\Routing\LinkGeneratorTrait in class Drupal\social_post\PostListBuilder:  
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                                                       
         Use \Drupal\Core\Link instead.                                                                                 
 ------ --------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/social_features/social_post/src/PostViewBuilder.php                  
 ------ ----------------------------------------------------------------------------- 
  213    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityBase:  
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                      
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                    
  221    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityBase:  
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                      
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.                    
 ------ ----------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_profile/modules/social_profile_fields/src/SocialProfileFieldsBatch.php  
 ------ ------------------------------------------------------------------------------------------------------- 
  86     Call to deprecated function drupal_set_message():                                                      
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                                               
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.                                   
 ------ ------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   modules/social_features/social_profile/social_profile.install  
 ------ --------------------------------------------------------------- 
  46     Call to deprecated function file_unmanaged_copy():             
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.          
         Use \Drupal\Core\File\FileSystemInterface::copy().             
 ------ --------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   modules/social_features/social_profile/social_profile.module              
 ------ -------------------------------------------------------------------------- 
  129    Call to deprecated method entityManager() of class Drupal:                
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal::entityTypeManager() instead in most cases. If the needed     
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the  
         deprecated \Drupal\Core\Entity\EntityManager to find the                  
         correct interface or service.                                             
 ------ -------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   modules/social_features/social_tagging/social_tagging.module                       
 ------ ----------------------------------------------------------------------------------- 
  278    Call to deprecated method getVocabularyId() of class Drupal\taxonomy\Entity\Term:  
         Scheduled for removal before Drupal 9.0.0. Use                                     
         TermInterface::bundle() instead.                                                   
  280    Call to deprecated function db_delete():                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get                  
         a database connection injected into your service from the container and            
         call delete() on it. For example,                                                  
  281    Call to deprecated function db_delete():                                           
         as of Drupal 8.0.x, will be removed in Drupal 9.0.0. Instead, get                  
         a database connection injected into your service from the container and            
         call delete() on it. For example,                                                  
 ------ ----------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   modules/social_features/social_user/src/Form/SocialUserLoginForm.php  
 ------ ---------------------------------------------------------------------- 
  259    Call to deprecated method url() of class Drupal\Core\Form\FormBase:   
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.              
         Use \Drupal\Core\Url instead.                                         
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   modules/social_features/social_user/src/Form/SocialUserPasswordForm.php  
 ------ ------------------------------------------------------------------------- 
  89     Call to deprecated function drupal_set_message():                        
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                 
         Use \Drupal\Core\Messenger\MessengerInterface::addMessage() instead.     
 ------ ------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/social_features/social_user/tests/src/Unit/Validation/Constraint/SocialUserNameConstraintTest.php                       
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
         Class Drupal\social_user\Tests\SocialUserNameConstraintTest was not found while trying to analyse it - autoloading is probably  
         not configured properly.                                                                                                        
 ------ -------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   modules/social_features/social_user_export/src/Plugin/Action/ExportUser.php  
 ------ ----------------------------------------------------------------------------- 
  142    Call to deprecated function file_prepare_directory():                        
         in Drupal 8.7.0, will be removed before Drupal 9.0.0.                        
         Use \Drupal\Core\File\FileSystemInterface::prepareDirectory().               
 ------ ----------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------- 
  Line   social.profile                                                            
 ------ -------------------------------------------------------------------------- 
  279    Call to deprecated function drupal_get_messages():                        
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal\Core\Messenger\MessengerInterface::all() or                   
         \Drupal\Core\Messenger\MessengerInterface::messagesByType() instead.      
  353    Call to deprecated function drupal_get_messages():                        
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal\Core\Messenger\MessengerInterface::all() or                   
         \Drupal\Core\Messenger\MessengerInterface::messagesByType() instead.      
  386    Call to deprecated function drupal_get_messages():                        
         in Drupal 8.5.0 and will be removed before Drupal 9.0.0.                  
         Use \Drupal\Core\Messenger\MessengerInterface::all() or                   
         \Drupal\Core\Messenger\MessengerInterface::messagesByType() instead.      
  454    Call to deprecated function drupal_get_profile():                         
         in Drupal 8.3.0, will be removed before Drupal 9.0.0.                     
         Use the install_profile container parameter or \Drupal::installProfile()  
         instead. If you are accessing the value before it is written to           
         configuration during the installer use the $install_state global. If you  
         need to access the value before container is available you can use        
         BootstrapConfigStorageFactory to load the value directly from             
         configuration.                                                            
 ------ -------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------- 
  Line   tests/behat/features/bootstrap/FeatureContext.php                                                                      
 ------ ----------------------------------------------------------------------------------------------------------------------- 
  20     Class Drupal\social\Behat\FeatureContext implements deprecated interface Behat\Behat\Context\SnippetAcceptingContext:  
         will be removed in 4.0. Use --snippets-for CLI option instead                                                          
  375    Call to deprecated method xpathLiteral() of class Behat\Mink\Selector\SelectorsHandler:                                
         since Mink 1.7. Use \Behat\Mink\Selector\Xpath\Escaper::escapeLiteral when building Xpath                              
         or pass the unescaped value when using the named selector.                                                             
  601    Call to deprecated function entity_load_multiple():                                                                    
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the                                                       
         entity type storage's loadMultiple() method.                                                                           
  737    Call to deprecated method url() of class Drupal\file\Entity\File:                                                      
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                                                                
         Please use toUrl() instead.                                                                                            
  836    Call to deprecated function entity_load():                                                                             
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the                                                          
         entity type storage's load() method.                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------- 
  Line   tests/behat/features/bootstrap/PostContext.php                                                                      
 ------ -------------------------------------------------------------------------------------------------------------------- 
  20     Class Drupal\social\Behat\PostContext implements deprecated interface Behat\Behat\Context\SnippetAcceptingContext:  
         will be removed in 4.0. Use --snippets-for CLI option instead                                                       
  35     Call to deprecated function entity_load_multiple():                                                                 
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use the                                                    
         entity type storage's loadMultiple() method.                                                                        
 ------ -------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   tests/behat/features/bootstrap/SocialDrupalContext.php         
 ------ --------------------------------------------------------------- 
  52     Call to deprecated function user_load():                       
         iin Drupal 8.0.0 and will be removed before Drupal 9.0.0. Use  
         Drupal\user\Entity\User::load().                               
 ------ --------------------------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   themes/socialbase/includes/form.inc                               
 ------ ------------------------------------------------------------------ 
  87     Call to deprecated function drupal_render():                      
         as of Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the  
  100    Call to deprecated function entity_load():                        
         in Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the     
         entity type storage's load() method.                              
 ------ ------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------- 
  Line   themes/socialbase/socialbase.theme                                             
 ------ ------------------------------------------------------------------------------- 
  50     Call to deprecated method link() of class Drupal\Core\Entity\EntityInterface:  
         in Drupal 8.0.0, intended to be removed in Drupal 9.0.0                        
         Use \Drupal\Core\EntityInterface::toLink()->toString() instead.                
 ------ ------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   themes/socialbase/src/Plugin/Preprocess/Block.php                                  
 ------ ----------------------------------------------------------------------------------- 
  47     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:  
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                       
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                  
  65     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:  
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                       
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                  
  136    Call to deprecated method entityManager() of class Drupal:                         
         in Drupal 8.0.0 and will be removed before Drupal 9.0.0.                           
         Use \Drupal::entityTypeManager() instead in most cases. If the needed              
         method is not on \Drupal\Core\Entity\EntityTypeManagerInterface, see the           
         deprecated \Drupal\Core\Entity\EntityManager to find the                           
         correct interface or service.                                                      
 ------ ----------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------- 
  Line   themes/socialbase/src/Plugin/Preprocess/FileLink.php                               
 ------ ----------------------------------------------------------------------------------- 
  31     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:  
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                       
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                  
  32     Call to deprecated method getBaseThemes() of class Drupal\Core\Theme\ActiveTheme:  
         in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Use                       
         \Drupal\Core\Theme\ActiveTheme::getBaseThemeExtensions() instead.                  
 ------ ----------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   themes/socialbase/src/Plugin/Preprocess/Node.php                  
 ------ ------------------------------------------------------------------ 
  55     Call to deprecated function drupal_render():                      
         as of Drupal 8.0.x, will be removed before Drupal 9.0.0. Use the  
 ------ ------------------------------------------------------------------ 

                                                                                                                        
 [ERROR] Found 226 errors                                                                                               
                                                                                                                        
```