### PR TITLE
Improve Docker performance by adding :delegated to volumes

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,7 +4,7 @@ services:
   web_scripts:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     environment:
      - DRUPAL_SETTINGS=production
     network_mode: "bridge"
@@ -13,7 +13,7 @@ services:
   web:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - db:db
      - mailcatcher:mailcatcher
@@ -52,7 +52,7 @@ services:
     links:
      - web:web
     volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files
+      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
     ports:
      - "4444"
      - "5900"
@@ -65,7 +65,7 @@ services:
   behat:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - web:web
      - db:db

--- a/docker-compose.blackfire.yml
+++ b/docker-compose.blackfire.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - db
      - mailcatcher
@@ -45,7 +45,7 @@ services:
   selenium:
     image: selenium/standalone-firefox-debug:2.48.2
     volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files
+      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
     links:
      - web:web
     ports:
@@ -60,7 +60,7 @@ services:
   behat:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - web:web
      - db:db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - db
      - mailcatcher
@@ -44,7 +44,7 @@ services:
   selenium:
     image: selenium/standalone-firefox-debug:2.48.2
     volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files
+      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
     links:
      - web:web
     ports:
@@ -59,7 +59,7 @@ services:
   behat:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - web:web
      - db:db
@@ -72,7 +72,7 @@ services:
   cron:
     image: goalgorilla/open_social_docker:cron
     volumes:
-     - ./:/var/www
+     - ./:/var/www:delegated
     links:
      - db
      - mailcatcher


### PR DESCRIPTION
By adding `:delegated` to the Docker volumes the performance increases drastically.

> The `delegated` configuration provides the weakest set of guarantees. For directories mounted with `delegated` the container’s view of the file system is authoritative, and writes performed by containers may not be immediately reflected on the host file system.