### PR TITLE
Move to `drupal/social`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "roave/security-advisories": "dev-master",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "10.0.x-dev",
+        "drupal/social": "10.0.x-dev",
         "goalgorilla/open_social_scripts": "dev-master",
         "drupal/redis": "^1.2",
         "blackfire/php-sdk": "^1.19"


### PR DESCRIPTION
This PR should not be merged until all open PRs in the goalgorilla/open_social repo are switch over.

**After merging, do not delete this branch until all the `.travis.yml` of the Open Social repo has been updated back to `master`!**