### PR TITLE
Drupal 9.2.x update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "drush/drush": "10.*@stable",
-        "goalgorilla/open_social": "dev-main",
+        "goalgorilla/open_social": "dev-update/drupal-core-9.2.x ",
         "goalgorilla/open_social_scripts": "^2.0",
         "drupal/redis": "^1.5",
         "blackfire/php-sdk": "^v1.27.1"
@@ -21,7 +21,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
         "drupal/coder": "8.3.13",
         "drupal/composer_deploy": "^1.6",
-        "drupal/core-dev": "~9.1.0",
+        "drupal/core-dev": "~9.2.0",
         "drupal/devel": "^4.1",
         "drupal/drupal-extension": "^4.1",
         "drupal/upgrade_status": "^3.11",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "drush/drush": "10.*@stable",
-        "goalgorilla/open_social": "dev-update/drupal-core-9.2.x ",
+        "goalgorilla/open_social": "dev-main",
         "goalgorilla/open_social_scripts": "^2.0",
         "drupal/redis": "^1.5",
         "blackfire/php-sdk": "^v1.27.1"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
-        "drupal/coder": "8.3.13",
+        "drupal/coder": "^8.3",
         "drupal/composer_deploy": "^1.6",
         "drupal/core-dev": "~9.2.0",
         "drupal/devel": "^4.1",


### PR DESCRIPTION
- Updated drupal/core-dev to `~9.2.0`
- Temporarily require `"goalgorilla/open_social": "dev-update/drupal-core-9.2.x "`