### PR TITLE
Added PHP 8.0 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 language: php
 
 php:
-  - 7.4
+  - 8.1
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 sudo: required
 
 cache:
@@ -14,12 +14,18 @@ addons:
 language: php
 
 php:
-  - 8.0
+  - 8.0.19
+
+env:
+  global:
+    # Travis Token.
+    secure: "u6jLZiftQdb8Ozxngu5sgwmnXeUyvNF3/Y+5eX3+Xyb7Sm6K++cBLbYl/zNbuzp1rZE5dn3pVTQc4tstVXZw2B5KjCd64r9HE9gdwCEnS/AA/w3wGlaEBinTzKOrrN1EvqNNhnJUY2JmqEYVom+UYwLZWIIKM/5OoaeidNqHDvImZZLAeYfPMGnySsFC01yCzrOn6jv8Bwu00dQPVEOQylVEV5qgdGYz6CvGGslcvGxhvR0qdY/IXhrA0yxIk1yA6vu1mQpCSjGpPLy024JhcqRr3AzjH2N0QRKlL7vcNFxl/OC0qcK2bOl8lcQydeC5LRp92eeCLfMfvqHDqLJKvebCsvaZSmqlzCURlcHaJOM5bce7XPVyNLdwnfppgSacocGol38qxfEc09qV4AZnklwigYCfnk346oSaocKApy48KRW4cNXL45U7+z10IzVAENGwbyyuwdvKHhDtMCgMd8eeYfRF5EvENOKVSG02Kca8X2fLBhmJsXkFcBEW7pSRZKxixkIkuAwEYSQW/lvvM4LJmd2np7vZDEMh1dmf7TBRBygDVmM7vtdYRSzivR/T9nH+mXPP9FcjVvlPPeWAEaqtLPmmONmYRjDRcoHjJh3YnSMpvVs8wejDf7iS6A44cI6xZQRoEoCFA/WUu5EnzmoOCY7HvZ62xnZ0I9nNyL4="
 
 services:
   - docker
 
 before_install:
+  - set -e
   # Composer Configurations.
   - export COMPOSER_MEMORY_LIMIT=-1 # Set php memory limit to -1 so composer update will not fail
   - export COMPOSER_EXIT_ON_PATCH_FAILURE=1 # To enforce throwing an error and stopping package installation/update immediately

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 language: php
 
 php:
-  - 8.0.19
+  - 8.0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 language: php
 
 php:
-  - 8.1
+  - 8.0
 
 services:
   - docker

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
         "drush/drush": "11.*@stable",
-        "goalgorilla/open_social": "dev-feature/3260861-php-8-support-updated-branch",
+        "goalgorilla/open_social": "dev-main",
         "goalgorilla/open_social_scripts": "^3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
         "drupal/coder": "^8.3",
         "drupal/composer_deploy": "^1.6",
-        "drupal/core-dev": "~9.3.12",
+        "drupal/core-dev": "~9.3.15",
         "drupal/devel": "^4.1",
         "drupal/drupal-extension": "^4.1",
         "drupal/upgrade_status": "^3.11",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
         "drush/drush": "11.*@stable",
-        "goalgorilla/open_social": "dev-main",
-        "goalgorilla/open_social_scripts": "^3.0"
+        "goalgorilla/open_social": "dev-feature/3260861-php-8-support-updated-branch",
+        "goalgorilla/open_social_scripts": "^3.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,8 +1,10 @@
+# See: https://docs.docker.com/compose/compose-file/
+# See: https://github.com/compose-spec/compose-spec/blob/master/spec.md
 version: "2"
 
 services:
   web_scripts:
-    image: goalgorilla/open_social_docker:ci
+    image: goalgorilla/open_social_docker:cid9
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -12,7 +14,7 @@ services:
     container_name: social_ci_web_scripts
 
   web:
-    image: goalgorilla/open_social_docker:ci
+    image: goalgorilla/open_social_docker:cid9
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -34,7 +36,7 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     ports:
-      - "3307:3306"
+      - "3306"
     container_name: social_ci_db
     command: mysqld --max_allowed_packet=16M
 
@@ -62,7 +64,7 @@ services:
     container_name: social_ci_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:ci
+    image: goalgorilla/open_social_docker:cid9
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
   web_scripts:
-    image: goalgorilla/open_social_docker:cid9
+    image: goalgorilla/open_social_docker:ci
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -14,7 +14,7 @@ services:
     container_name: social_ci_web_scripts
 
   web:
-    image: goalgorilla/open_social_docker:cid9
+    image: goalgorilla/open_social_docker:ci
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -64,7 +64,7 @@ services:
     container_name: social_ci_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:cid9
+    image: goalgorilla/open_social_docker:ci
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.blackfire.yml
+++ b/docker-compose.blackfire.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   web:
-    image: goalgorilla/open_social_docker:dev
+    image: goalgorilla/open_social_docker:d9
     volumes:
      - ./:/var/www:delegated
     links:
@@ -58,7 +58,7 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:dev
+    image: goalgorilla/open_social_docker:d9
     volumes:
      - ./:/var/www:delegated
     links:

--- a/docker-compose.blackfire.yml
+++ b/docker-compose.blackfire.yml
@@ -1,11 +1,9 @@
-version: "2"
-
 services:
   web:
-    image: goalgorilla/open_social_docker:d9
+    image: goalgorilla/open_social_docker:devd9
     volumes:
      - ./:/var/www:delegated
-    links:
+    depends_on:
      - db
      - mailcatcher
      - redis
@@ -46,8 +44,8 @@ services:
     image: selenium/standalone-firefox-debug:2.48.2
     volumes:
       - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
-    links:
-     - web:web
+    depends_on:
+     - web
     ports:
      - "4444"
      - "5900"
@@ -58,13 +56,13 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:d9
+    image: goalgorilla/open_social_docker:devd9
     volumes:
      - ./:/var/www:delegated
-    links:
-     - web:web
-     - db:db
-     - selenium:selenium
+    depends_on:
+     - web
+     - db
+     - selenium
     environment:
      - DRUPAL_SETTINGS=development
     network_mode: "bridge"
@@ -85,7 +83,7 @@ services:
     image: goalgorilla/open_social_docker:cron
     volumes:
      - ./:/var/www
-    links:
+    depends_on:
      - db
      - mailcatcher
     environment:

--- a/docker-compose.blackfire.yml
+++ b/docker-compose.blackfire.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: goalgorilla/open_social_docker:devd9
+    image: goalgorilla/open_social_docker:dev
     volumes:
      - ./:/var/www:delegated
     depends_on:
@@ -56,7 +56,7 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:devd9
+    image: goalgorilla/open_social_docker:dev
     volumes:
      - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # See: https://github.com/compose-spec/compose-spec/blob/master/spec.md
 services:
   web:
-    image: goalgorilla/open_social_docker:devd9
+    image: goalgorilla/open_social_docker:dev
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -53,7 +53,7 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:devd9
+    image: goalgorilla/open_social_docker:dev
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
+# See: https://docs.docker.com/compose/compose-file/
+# See: https://github.com/compose-spec/compose-spec/blob/master/spec.md
 services:
   web:
-    image: goalgorilla/open_social_docker:d9
+    image: goalgorilla/open_social_docker:devd9
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -51,7 +53,7 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:d9
+    image: goalgorilla/open_social_docker:devd9
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: goalgorilla/open_social_docker:dev
+    image: goalgorilla/open_social_docker:d9
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -51,7 +51,7 @@ services:
     container_name: social_selenium
 
   behat:
-    image: goalgorilla/open_social_docker:dev
+    image: goalgorilla/open_social_docker:d9
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   //   Should we try and load \Drupal::VERSION and check?
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8-all-deprecations.php');
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-9/drupal-9-all-deprecations.php');
-  $containerConfigurator->import(SetList::PHP_81);
+  $containerConfigurator->import(SetList::PHP_80);
   $parameters = $containerConfigurator->parameters();
 
   $drupalFinder = new DrupalFinder();
@@ -37,7 +37,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $drupalRoot . '/themes',
   ]);
 
-  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_81);
+  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
   $parameters->set(Option::SKIP, ['*/upgrade_status/tests/modules/*']);
   $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
   $parameters->set(Option::AUTO_IMPORT_NAMES, TRUE);

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   //   Should we try and load \Drupal::VERSION and check?
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8-all-deprecations.php');
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-9/drupal-9-all-deprecations.php');
-  $containerConfigurator->import(SetList::PHP_74);
+  $containerConfigurator->import(SetList::PHP_81);
   $parameters = $containerConfigurator->parameters();
 
   $drupalFinder = new DrupalFinder();
@@ -37,7 +37,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $drupalRoot . '/themes',
   ]);
 
-  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
+  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_81);
   $parameters->set(Option::SKIP, ['*/upgrade_status/tests/modules/*']);
   $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
   $parameters->set(Option::AUTO_IMPORT_NAMES, TRUE);


### PR DESCRIPTION
1. Update Drupal core version to 9.3.5 which supports PHP 8.0
2. Updated travis configutation to install PHP 8.0
3. Updated rector.php file to check againt PHP 8.0
4. Changes from https://github.com/goalgorilla/open_social_docker/pull/19 are included for Docker image.
5. Temporarily added: https://github.com/goalgorilla/open_social_scripts/pull/44 branch.