### PR TITLE
Ugraded our docker compose files to compose specifications.

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,28 +4,26 @@ services:
   web_scripts:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - db:db
+      - ./:/var/www:delegated
+    depends_on:
+      - db
     environment:
-     - DRUPAL_SETTINGS=production
-    network_mode: "bridge"
+      - DRUPAL_SETTINGS=production
     container_name: social_ci_web_scripts
 
   web:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - db:db
-     - mailcatcher:mailcatcher
-     - redis
-     - solr
+      - ./:/var/www:delegated
+    depends_on:
+      - db
+      - mailcatcher
+      - redis
+      - solr
     environment:
-     - DRUPAL_SETTINGS=production
+      - DRUPAL_SETTINGS=production
     ports:
-     - "80"
-    network_mode: "bridge"
+      - "80"
     container_name: social_ci_web
 
   db:
@@ -34,10 +32,9 @@ services:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=social
     volumes:
-     - db_data:/var/lib/mysql
+      - db_data:/var/lib/mysql
     ports:
       - "3307:3306"
-    network_mode: "bridge"
     container_name: social_ci_db
     command: mysqld --max_allowed_packet=16M
 
@@ -48,36 +45,33 @@ services:
       - VIRTUAL_PORT=1080
     ports:
       - "1080"
-    network_mode: "bridge"
     container_name: social_mailcatcher
 
   selenium:
     image: selenium/standalone-firefox-debug:2.48.2
-    links:
-     - web:web
+    depends_on:
+      - web
     volumes:
       - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
     ports:
-     - "4444"
-     - "5900"
+      - "4444"
+      - "5900"
     cap_add:
-     - NET_ADMIN
-     - NET_RAW
-    network_mode: "bridge"
+      - NET_ADMIN
+      - NET_RAW
     container_name: social_ci_selenium
 
   behat:
     image: goalgorilla/open_social_docker:ci
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - web:web
-     - db:db
-     - selenium:selenium
-     - mailcatcher:mailcatcher
+      - ./:/var/www:delegated
+    depends_on:
+      - web
+      - db
+      - selenium
+      - mailcatcher
     environment:
-     - DRUPAL_SETTINGS=production
-    network_mode: "bridge"
+      - DRUPAL_SETTINGS=production
     container_name: social_ci_behat
 
   solr:
@@ -97,12 +91,10 @@ services:
       - solr-precreate
       - drupal
       - /solr-conf
-    network_mode: "bridge"
     container_name: social_ci_solr
 
   redis:
     image: redis:latest
-    network_mode: "bridge"
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
     depends_on:
-      - web:web
+      - web
     ports:
       - "4444"
       - "5900"
@@ -55,9 +55,9 @@ services:
     volumes:
       - ./:/var/www:delegated
     depends_on:
-      - web:web
-      - db:db
-      - selenium:selenium
+      - web
+      - db
+      - selenium
     environment:
       - DRUPAL_SETTINGS=development
     container_name: social_behat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,18 @@
-version: "2"
-
 services:
   web:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - db
-     - mailcatcher
-     - redis
-     - solr
+      - ./:/var/www:delegated
+    depends_on:
+      - db
+      - mailcatcher
+      - redis
+      - solr
     environment:
-     - VIRTUAL_HOST=social.local
-     - DRUPAL_SETTINGS=development
+      - VIRTUAL_HOST=social.local
+      - DRUPAL_SETTINGS=development
     ports:
-     - "80"
-    network_mode: "bridge"
+      - "80"
     container_name: social_web
 
   db:
@@ -27,7 +24,6 @@ services:
       - db_data:/var/lib/mysql
     ports:
       - "3306"
-    network_mode: "bridge"
     container_name: social_db
     command: mysqld --max_allowed_packet=16M
 
@@ -38,47 +34,43 @@ services:
       - VIRTUAL_PORT=1080
     ports:
       - "1080"
-    network_mode: "bridge"
     container_name: social_mailcatcher
 
   selenium:
     image: selenium/standalone-firefox-debug:2.48.2
     volumes:
       - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
-    links:
-     - web:web
+    depends_on:
+      - web:web
     ports:
-     - "4444"
-     - "5900"
+      - "4444"
+      - "5900"
     cap_add:
-     - NET_ADMIN
-     - NET_RAW
-    network_mode: "bridge"
+      - NET_ADMIN
+      - NET_RAW
     container_name: social_selenium
 
   behat:
     image: goalgorilla/open_social_docker:dev
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - web:web
-     - db:db
-     - selenium:selenium
+      - ./:/var/www:delegated
+    depends_on:
+      - web:web
+      - db:db
+      - selenium:selenium
     environment:
-     - DRUPAL_SETTINGS=development
-    network_mode: "bridge"
+      - DRUPAL_SETTINGS=development
     container_name: social_behat
 
   cron:
     image: goalgorilla/open_social_docker:cron
     volumes:
-     - ./:/var/www:delegated
-    links:
-     - db
-     - mailcatcher
+      - ./:/var/www:delegated
+    depends_on:
+      - db
+      - mailcatcher
     environment:
-     - DRUPAL_SETTINGS=development
-    network_mode: "bridge"
+      - DRUPAL_SETTINGS=development
     container_name: social_cron
 
   solr:
@@ -98,12 +90,10 @@ services:
       - solr-precreate
       - drupal
       - /solr-conf
-    network_mode: "bridge"
     container_name: social_solr
 
   redis:
     image: redis:latest
-    network_mode: "bridge"
 
 volumes:
   db_data:


### PR DESCRIPTION
1. Updated our docker-compose files to the latest compose specification version from v2. See:
 
https://docs.docker.com/compose/compose-file/compose-versioning/
https://docs.docker.com/compose/compose-file/compose-versioning/#upgrading

2. Removed links and network bridge keys as they are default behavior.
3. Added depends_on key to make sure contains are ready before other containers need them.
4. Read more about them here: https://github.com/compose-spec/compose-spec/blob/master/spec.md
5. This adds 'Docker compose v2' support. Read more here: https://docs.docker.com/compose/cli-command/