### PR TITLE
Replace the asset-packagist repository with custom defined packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
         "drush/drush": "10.*@stable",
-        "goalgorilla/open_social": "dev-main",
+        "goalgorilla/open_social": "dev-feature/3275931-replace-the-asset-packagist-repository",
         "goalgorilla/open_social_scripts": "^3.0"
     },
     "require-dev": {
@@ -49,17 +49,13 @@
         "squizlabs/html_codesniffer": "*",
         "symplify/easy-coding-standard": "^9.4"
     },
-    "repositories": {
-        "0": {
+    "repositories": [
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8",
             "exclude": ["goalgorilla/open_social", "drupal/social"]
         },
-        "1": {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        },
-        "2": {
+        {
             "type": "package",
             "package": {
                 "name": "squizlabs/html_codesniffer",
@@ -71,12 +67,246 @@
                 }
             }
         },
-        "3": {
+        {
             "type": "git",
             "url": "https://github.com/goalgorilla/open_social.git",
             "only": ["goalgorilla/open_social", "drupal/social"]
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/autosize",
+                "version": "4.0.4",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/blazy",
+                "version": "1.8.2",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/blazy/-/blazy-1.8.2.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/bootstrap",
+                "version": "3.4.1",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/d3",
+                "version": "3.5.17",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/diff",
+                "version": "3.5.0",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/highlight.js",
+                "version": "9.15.10",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/jquery.caret",
+                "version": "0.3.1",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/jquery.caret/-/jquery.caret-0.3.1.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/jquery-ui-touch-punch",
+                "version": "0.2.3",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/jquery-ui-touch-punch/-/jquery-ui-touch-punch-0.2.3.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/morris.js06",
+                "version": "0.6.6",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/morris.js06/-/morris.js06-0.6.6.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/node-waves",
+                "version": "0.7.6",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/node-waves/-/node-waves-0.7.6.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/photoswipe",
+                "version": "4.1.3",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/photoswipe/-/photoswipe-4.1.3.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/raphael",
+                "version": "2.2.8",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/raphael/-/raphael-2.2.8.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/react",
+                "version": "16.14.0",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/react/-/react-16.14.0.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/react-dom",
+                "version": "16.14.0",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/select2",
+                "version": "4.0.13",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/shariff",
+                "version": "3.2.1",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/shariff/-/shariff-3.2.1.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/slick-carousel",
+                "version": "1.8.1",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/tablesaw",
+                "version": "3.1.2",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/tablesaw/-/tablesaw-3.1.2.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "bower-asset/lazysizes",
+                "version": "5.3.1",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/aFarkas/lazysizes.git",
+                    "reference": "81cf774c6a7f4d8f7f3909e225a65d8acb10cb20"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/aFarkas/lazysizes/zipball/81cf774c6a7f4d8f7f3909e225a65d8acb10cb20",
+                    "reference": "81cf774c6a7f4d8f7f3909e225a65d8acb10cb20"
+                },
+                "type": "bower-asset"
+            }
         }
-    },
+    ],
     "scripts": {
         "refresh": [
             "rm -rf composer.lock vendor html/core html/modules/contrib html/profiles/contrib html/themes/contrib",

--- a/composer.json
+++ b/composer.json
@@ -49,13 +49,16 @@
         "squizlabs/html_codesniffer": "*",
         "symplify/easy-coding-standard": "^9.4"
     },
-    "repositories": [
-        {
+    "repositories": {
+        "0": {
             "type": "composer",
             "url": "https://packages.drupal.org/8",
-            "exclude": ["goalgorilla/open_social", "drupal/social"]
+            "exclude": [
+                "goalgorilla/open_social",
+                "drupal/social"
+            ]
         },
-        {
+        "squizlabs/html_codesniffer": {
             "type": "package",
             "package": {
                 "name": "squizlabs/html_codesniffer",
@@ -67,12 +70,15 @@
                 }
             }
         },
-        {
+        "goalgorilla/open_social": {
             "type": "git",
             "url": "https://github.com/goalgorilla/open_social.git",
-            "only": ["goalgorilla/open_social", "drupal/social"]
+            "only": [
+                "goalgorilla/open_social",
+                "drupal/social"
+            ]
         },
-        {
+        "npm-asset/autosize": {
             "type": "package",
             "package": {
                 "name": "npm-asset/autosize",
@@ -84,7 +90,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/blazy": {
             "type": "package",
             "package": {
                 "name": "npm-asset/blazy",
@@ -96,7 +102,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/bootstrap": {
             "type": "package",
             "package": {
                 "name": "npm-asset/bootstrap",
@@ -108,7 +114,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/d3": {
             "type": "package",
             "package": {
                 "name": "npm-asset/d3",
@@ -120,7 +126,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/diff": {
             "type": "package",
             "package": {
                 "name": "npm-asset/diff",
@@ -132,7 +138,19 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/eve-raphael": {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/eve-raphael",
+                "version": "0.5.0",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        "npm-asset/highlight.js": {
             "type": "package",
             "package": {
                 "name": "npm-asset/highlight.js",
@@ -144,7 +162,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/jquery.caret": {
             "type": "package",
             "package": {
                 "name": "npm-asset/jquery.caret",
@@ -156,7 +174,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/jquery-ui-touch-punch": {
             "type": "package",
             "package": {
                 "name": "npm-asset/jquery-ui-touch-punch",
@@ -168,7 +186,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/morris.js06": {
             "type": "package",
             "package": {
                 "name": "npm-asset/morris.js06",
@@ -180,7 +198,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/node-waves": {
             "type": "package",
             "package": {
                 "name": "npm-asset/node-waves",
@@ -192,7 +210,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/photoswipe": {
             "type": "package",
             "package": {
                 "name": "npm-asset/photoswipe",
@@ -204,7 +222,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/raphael": {
             "type": "package",
             "package": {
                 "name": "npm-asset/raphael",
@@ -216,7 +234,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/react": {
             "type": "package",
             "package": {
                 "name": "npm-asset/react",
@@ -228,7 +246,19 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/loose-envify": {
+            "type": "package",
+            "package": {
+                "name": "npm-asset/loose-envify",
+                "version": "1.4.0",
+                "dist": {
+                    "type": "tar",
+                    "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
+                },
+                "type": "npm-asset"
+            }
+        },
+        "npm-asset/react-dom": {
             "type": "package",
             "package": {
                 "name": "npm-asset/react-dom",
@@ -240,7 +270,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/select2": {
             "type": "package",
             "package": {
                 "name": "npm-asset/select2",
@@ -252,7 +282,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/shariff": {
             "type": "package",
             "package": {
                 "name": "npm-asset/shariff",
@@ -264,7 +294,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/slick-carousel": {
             "type": "package",
             "package": {
                 "name": "npm-asset/slick-carousel",
@@ -276,7 +306,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/tablesaw": {
             "type": "package",
             "package": {
                 "name": "npm-asset/tablesaw",
@@ -288,7 +318,7 @@
                 "type": "npm-asset"
             }
         },
-        {
+        "npm-asset/lazysizes": {
             "type": "package",
             "package": {
                 "name": "bower-asset/lazysizes",
@@ -306,7 +336,7 @@
                 "type": "bower-asset"
             }
         }
-    ],
+    },
     "scripts": {
         "refresh": [
             "rm -rf composer.lock vendor html/core html/modules/contrib html/profiles/contrib html/themes/contrib",

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
                 }
             }
         },
-        "goalgorilla/open_social": {
+        "goalgorilla/open_social/social": {
             "type": "git",
             "url": "https://github.com/goalgorilla/open_social.git",
             "only": [


### PR DESCRIPTION
## Problem
Unfortunately https://asset-packagist.org/ is not longer working, and because of it we can't install/update or test Open Social. 

## Solution
We need to replace https://asset-packagist.org/ by custom packages to be able to download the necessary libs

## Issue tracker
https://www.drupal.org/project/social/issues/3275931

## Theme issue tracker
N/A

## How to test
- [ ] One should be able to install this repository using composer;

## Definition of done
### Before merge
- [ ] Code/peer review is completed
- [ ] All commit messages are [clear and clean](https://open-social.slite.com/app/docs/DnmermZDIx_0OQ). If applicable a rebase was performed
- [ ] All automated tests are green
- [ ] Functional/manual tests of the acceptance criteria are approved
- [ ] All acceptance criteria were met
- [ ] If applicable (I.E. new hook_updates) the update path from previous versions (major and minor versions) are tested
- [ ] This pull request has all required labels (team/type/priority)
- [ ] This pull request has a milestone
- [ ] This pull request has an assignee (if applicable)
- [ ] Any front end changes are tested on all major browsers
- [ ] New UI elements, or changes on UI elements are approved by the design team
- [ ] New features, or feature changes are approved by the product owner

### After merge
- [ ] Code is tested on all branches that it has been cherry-picked
- [ ] Update hook number might need adjustment, make sure they have the correct order
- [ ] The Drupal.org ticket(s) are updated according to this pull request status

## Screenshots
N/A

## Release notes
N/A

## Change Record
N/A

## Translations
N/A
