### PR TITLE
Replace selenium and firefox with headless chrome

### DIFF
--- a/.github/workflows/behat-stability-1.yml
+++ b/.github/workflows/behat-stability-1.yml
@@ -42,4 +42,4 @@ jobs:
         run: docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh
 
       - name: Run Integration tests
-        run: docker exec -i social_ci_behat bash /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict --colors"
+        run: docker exec -i social_ci_web bash /var/www/scripts/social/behatstability.sh "stability-1 --stop-on-failure --strict --colors"

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,12 @@
     "require": {
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
-        "goalgorilla/open_social": "dev-main"
+        "goalgorilla/open_social": "dev-feature/headless-chrome",
+        "goalgorilla/open_social_scripts": "dev-feature/headless-chrome"
     },
     "require-dev": {
         "drupal/upgrade_status": "^3.11",
-        "goalgorilla/open_social_dev": "dev-main",
+        "goalgorilla/open_social_dev": "dev-feature/headless-chrome",
         "palantirnet/drupal-rector": "^0.12",
         "phpmd/phpmd": "^2.10",
         "slevomat/coding-standard": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     "require": {
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
-        "goalgorilla/open_social": "dev-feature/headless-chrome"
+        "goalgorilla/open_social": "dev-main"
     },
     "require-dev": {
         "drupal/upgrade_status": "^3.11",
-        "goalgorilla/open_social_dev": "dev-feature/headless-chrome",
+        "goalgorilla/open_social_dev": "dev-main",
         "palantirnet/drupal-rector": "^0.12",
         "phpmd/phpmd": "^2.10",
         "slevomat/coding-standard": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "require": {
         "blackfire/php-sdk": "^v1.27.1",
         "drupal/redis": "^1.5",
-        "goalgorilla/open_social": "dev-feature/headless-chrome",
-        "goalgorilla/open_social_scripts": "dev-feature/headless-chrome"
+        "goalgorilla/open_social": "dev-feature/headless-chrome"
     },
     "require-dev": {
         "drupal/upgrade_status": "^3.11",

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -49,32 +49,19 @@ services:
       - "1080"
     container_name: social_mailcatcher
 
-  selenium:
-    image: selenium/standalone-firefox-debug:2.48.2
-    depends_on:
-      - web
-    volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
-    ports:
-      - "4444"
-      - "5900"
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    container_name: social_ci_selenium
-
-  behat:
-    image: goalgorilla/open_social_docker:ci
+  chrome:
+    image: zenika/alpine-chrome
+    container_name: social_chrome
+    command:
+      - "--headless" # Run in headless mode, i.e., without a UI or display server dependencies.
+      - "--disable-gpu" # Disables GPU hardware acceleration. If software renderer is not in place, then the GPU process won't launch.
+      - "--no-sandbox" # Disables the sandbox for all process types that are normally sandboxed. Meant to be used as a browser-level switch for testing purposes only.
+      - "--remote-debugging-address=0.0.0.0" # Enables remote debug over HTTP on the specified port.
+      - "--remote-debugging-port=9222" # Enables remote debug over HTTP on the specified port.
     volumes:
       - ./:/var/www:delegated
-    depends_on:
-      - web
-      - db
-      - selenium
-      - mailcatcher
-    environment:
-      - DRUPAL_SETTINGS=production
-    container_name: social_ci_behat
+    ports:
+      - '9222:9222'
 
   solr:
     image: solr:8.11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,31 +39,19 @@ services:
       - "1080"
     container_name: "${PROJECT_NAME}_mailcatcher"
 
-  selenium:
-    image: selenium/standalone-firefox-debug:2.48.2
-    volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
-    depends_on:
-      - web
-    ports:
-      - "4444"
-      - "5900"
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    container_name: "${PROJECT_NAME}_selenium"
-
-  behat:
-    image: goalgorilla/open_social_docker:dev
+  chrome:
+    image: zenika/alpine-chrome
+    container_name: "${PROJECT_NAME}_chrome"
+    command:
+      - "--headless" # Run in headless mode, i.e., without a UI or display server dependencies.
+      - "--disable-gpu" # Disables GPU hardware acceleration. If software renderer is not in place, then the GPU process won't launch.
+      - "--no-sandbox" # Disables the sandbox for all process types that are normally sandboxed. Meant to be used as a browser-level switch for testing purposes only.
+      - "--remote-debugging-address=0.0.0.0" # Enables remote debug over HTTP on the specified port.
+      - "--remote-debugging-port=9222" # Enables remote debug over HTTP on the specified port.
     volumes:
       - ./:/var/www:delegated
-    depends_on:
-      - web
-      - db
-      - selenium
-    environment:
-      - DRUPAL_SETTINGS=development
-    container_name: "${PROJECT_NAME}_behat"
+    ports:
+      - '9222:9222'
 
   cron:
     image: goalgorilla/open_social_docker:cron


### PR DESCRIPTION
With headless chrome we will be improving performance on our tests and moving away from the old firefox webdriver.