### PR TITLE
Set PHP 7.4 as base in Rector and ECS and remove upgrade_status module

### DIFF
--- a/.github/workflows/behat-stability-1.yml
+++ b/.github/workflows/behat-stability-1.yml
@@ -2,9 +2,8 @@ name: 'Behat'
 
 # Controls when the workflow will run
 on:
-  pull_request:
-    # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-35
-    types: [ ready_for_review, reopened, synchronize ]
+  # Triggers the workflow on all pull request events
+  pull_request: { }
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "goalgorilla/open_social": "dev-main"
     },
     "require-dev": {
-        "drupal/upgrade_status": "^3.11",
         "goalgorilla/open_social_dev": "dev-main",
         "palantirnet/drupal-rector": "^0.12",
         "phpmd/phpmd": "^2.10",

--- a/ecs.php
+++ b/ecs.php
@@ -16,7 +16,7 @@ return function (ContainerConfigurator $containerConfigurator): void {
 
   $parameters = $containerConfigurator->parameters();
   // Ena Parallel run.
-  $parameters->set(Option::PARALLEL, true);
+  $parameters->set(Option::PARALLEL, TRUE);
   $parameters->set(Option::SKIP, ['*/upgrade_status/tests/modules/*']);
   $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
 

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   //   Should we try and load \Drupal::VERSION and check?
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8-all-deprecations.php');
   $containerConfigurator->import(__DIR__ . '/vendor/palantirnet/drupal-rector/config/drupal-9/drupal-9-all-deprecations.php');
-  $containerConfigurator->import(SetList::PHP_80);
+  $containerConfigurator->import(SetList::PHP_74);
   $parameters = $containerConfigurator->parameters();
 
   $drupalFinder = new DrupalFinder();
@@ -37,12 +37,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $drupalRoot . '/themes',
   ]);
 
-  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
+  $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
   $parameters->set(Option::SKIP, ['*/upgrade_status/tests/modules/*']);
   $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
   $parameters->set(Option::AUTO_IMPORT_NAMES, TRUE);
   $parameters->set(Option::IMPORT_SHORT_CLASSES, FALSE);
-  $parameters->set(Option::IMPORT_DOC_BLOCKS, FALSE);
   $parameters->set('drupal_rector_notices_as_comments', TRUE);
   $services = $containerConfigurator->services();
   $services->set(ReturnTypeFromReturnNewRector::class);
@@ -55,8 +54,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $containerConfigurator->import(DoctrineSetList::DOCTRINE_CODE_QUALITY);
   // Auto import fully qualified class names? [default: false].
   $parameters->set(Option::AUTO_IMPORT_NAMES, TRUE);
-  // Skip classes used in PHP DocBlocks, like in /** @var \Some\Class */ [default: true].
-  $parameters->set(Option::IMPORT_DOC_BLOCKS, FALSE);
   // Path to phpstan with extensions, that PHPSTan in Rector uses to determine types.
   $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, getcwd() . '/html/profiles/contrib/social/phpstan.neon');
 };


### PR DESCRIPTION
Placeholder experimentation PR for https://github.com/goalgorilla/open_social/pull/3148

1. Remove upgrade_status requirement.
2. Set PHP 7.4 as basic.

This PR is rebased to minimum changes after we got green on the above mentioned PR.