### PR TITLE
Fix error on Linux machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - ./docker/solr/8.x/drupal/:/solr-conf/conf:cached
     environment:
       SOLR_SOLR_MEM_SIZE: 512m
-      PARTIAL_SEARCH_ENABLED: false
+      PARTIAL_SEARCH_ENABLED: 0
       VIRTUAL_HOST: "solr.${PROJECT_BASE_URL}"
       VIRTUAL_PORT: 8983
     ports:


### PR DESCRIPTION
There is an error on the Linux machine after executing `docker-compose up -d`
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.solr.environment.PARTIAL_SEARCH_ENABLED contains false, which is an invalid type, it should be a string, number, or a null
```