### PR TITLE
Removed the redundant cron docker container

### DIFF
--- a/docker-compose.blackfire.yml
+++ b/docker-compose.blackfire.yml
@@ -1,120 +1,20 @@
 services:
-  web:
-    image: goalgorilla/open_social_docker:dev
-    volumes:
-     - ./:/var/www:delegated
-    depends_on:
-     - db
-     - mailcatcher
-     - redis
-     - solr
-     - blackfire
-    environment:
-     - VIRTUAL_HOST=social.local
-     - DRUPAL_SETTINGS=development
-    ports:
-     - "80"
-    network_mode: "bridge"
-    container_name: social_web
-
-  db:
-    image: mariadb:10.7
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_DATABASE=social
-    volumes:
-      - db_data:/var/lib/mysql
-    ports:
-      - "3306"
-    network_mode: "bridge"
-    container_name: social_db
-    command: mysqld --max_allowed_packet=16M
-
-  mailcatcher:
-    image: schickling/mailcatcher
-    environment:
-      - VIRTUAL_HOST=mailcatcher.social.local
-      - VIRTUAL_PORT=1080
-    ports:
-      - "1080"
-    network_mode: "bridge"
-    container_name: social_mailcatcher
-
-  selenium:
-    image: selenium/standalone-firefox-debug:2.48.2
-    volumes:
-      - ./html/profiles/contrib/social/tests/behat/features/files/:/files:delegated
-    depends_on:
-     - web
-    ports:
-     - "4444"
-     - "5900"
-    cap_add:
-     - NET_ADMIN
-     - NET_RAW
-    network_mode: "bridge"
-    container_name: social_selenium
-
-  behat:
-    image: goalgorilla/open_social_docker:dev
-    volumes:
-     - ./:/var/www:delegated
-    depends_on:
-     - web
-     - db
-     - selenium
-    environment:
-     - DRUPAL_SETTINGS=development
-    network_mode: "bridge"
-    container_name: social_behat
-
   blackfire:
     image: blackfire/blackfire
     environment:
         # Exposes the host BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables.
         # Find the values for these on https://blackfire.io/docs/integrations/docker while logged in.
         # For ease of use on multiple project copy those export statements to ~/.bash_profile.
-        - BLACKFIRE_SERVER_ID
-        - BLACKFIRE_SERVER_TOKEN
-    network_mode: "bridge"
-    container_name: social_blackfire
-
-  cron:
-    image: goalgorilla/open_social_docker:cron
-    volumes:
-     - ./:/var/www
-    depends_on:
-     - db
-     - mailcatcher
-    environment:
-     - DRUPAL_SETTINGS=development
-    network_mode: "bridge"
-    container_name: social_cron
-
-  solr:
-    image: solr:8.11
-    hostname: solr
-    volumes:
-      - os_solr_data:/opt/solr/server/solr/mycores
-      - ./docker/solr/8.x/drupal/:/solr-conf/conf:cached
-    environment:
-      - SOLR_SOLR_MEM_SIZE=512m
-      - PARTIAL_SEARCH_ENABLED=false
-      - VIRTUAL_HOST=solr.social.local
-      - VIRTUAL_PORT=8983
+        BLACKFIRE_SERVER_ID
+        BLACKFIRE_SERVER_TOKEN
     ports:
-      - "8983"
-    entrypoint:
-      - solr-precreate
-      - drupal
-      - /solr-conf
-    network_mode: "bridge"
-    container_name: social_solr
+      - "8307"
+    container_name: "${PROJECT_NAME}_blackfire"
 
-  redis:
-    image: redis:latest
-    network_mode: "bridge"
-
-volumes:
-  db_data:
-  os_solr_data:
+networks:
+  # Default will connect all containers to the specified network.
+  default:
+    # Network name.
+    name: nginx
+    # Connects to an existing network.
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,17 +53,6 @@ services:
     ports:
       - '9222:9222'
 
-  cron:
-    image: goalgorilla/open_social_docker:cron
-    volumes:
-      - ./:/var/www:delegated
-    depends_on:
-      - db
-      - mailcatcher
-    environment:
-      - DRUPAL_SETTINGS=development
-    container_name: "${PROJECT_NAME}_cron"
-
   solr:
     image: solr:8.11
     hostname: solr


### PR DESCRIPTION
Allot of our developers were disabling the cron container for performance reasons, thus why we should remove the  container and when you actually need the cron, you can do it manually. For running the behat tests see: html/profiles/contrib/social/tests/behat/README.md.

We recently added the docker-compose.nginx.yml, which runs in addition to the default docker-compose.yml. To have the docker-compose files consistent with each other, the docker-compose.blackfire.yml should be adjusted to run in addition instead of standalone.