### PR TITLE
Add a specific tag to zenika/alpine-chrome docker-image

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -50,7 +50,7 @@ services:
     container_name: social_mailcatcher
 
   chrome:
-    image: zenika/alpine-chrome
+    image: zenika/alpine-chrome:89
     container_name: social_chrome
     command:
       - "--headless" # Run in headless mode, i.e., without a UI or display server dependencies.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     container_name: "${PROJECT_NAME}_mailcatcher"
 
   chrome:
-    image: zenika/alpine-chrome
+    image: zenika/alpine-chrome:102
     container_name: "${PROJECT_NAME}_chrome"
     command:
       - "--headless" # Run in headless mode, i.e., without a UI or display server dependencies.


### PR DESCRIPTION
When not specifying the tag, docker was using the latest flagged tag, and this was causing an issue with the chromeDriver, causing the behat tests to no run locally.

We tested the released tags and found out that tag number 102 is working as expected.

see: https://hub.docker.com/layers/zenika/alpine-chrome/102/images/sha256-1b2601ad344a34e8cd5ff9ceeb2b830649d71c5aa85f217f5c9732673fb86132?context=explore

### Before 

![image](https://user-images.githubusercontent.com/11061892/234240693-3f39e57c-5fd7-4c6d-aaac-fb50eec5cfdd.png)

### After

![image](https://user-images.githubusercontent.com/11061892/234241051-642fc99b-9e72-4f87-9d75-0854932013d4.png)
