### PR TITLE
Remove redundant and outdated dependency for slevomat/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "goalgorilla/open_social_dev": "dev-main",
         "palantirnet/drupal-rector": "^0.15",
         "phpmd/phpmd": "^2.10",
-        "slevomat/coding-standard": "^7.0",
         "squizlabs/html_codesniffer": "*",
         "symplify/easy-coding-standard": "^9.4"
     },


### PR DESCRIPTION
We are already adding a dev dependency for `goalgorilla/open_social_dev`, and this repo required `drupal/coder:8.3.20`, that requires the outdated redundant package

see: https://git.drupalcode.org/project/coder/-/blob/8.3.x/composer.json#L21
see: https://github.com/goalgorilla/open_social_dev/blob/main/composer.json#L9