### PR TITLE
Update our Doocker setup to use PHP 8.1 images

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
   web_scripts:
-    image: goalgorilla/open_social_docker:ci
+    image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -14,7 +14,7 @@ services:
     container_name: social_ci_web_scripts
 
   web:
-    image: goalgorilla/open_social_docker:ci
+    image: goalgorilla/open_social_docker:ci-d9.5-php8.1-v1
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # See: https://github.com/compose-spec/compose-spec/blob/master/spec.md
 services:
   web:
-    image: goalgorilla/open_social_docker:dev
+    image: goalgorilla/open_social_docker:d9.5-php8.1-v1
     volumes:
       - ./:/var/www:delegated
     depends_on:


### PR DESCRIPTION
Since we are not supporting PHP 8.1, let's update our docker images to use PHP 8.1

https://getopensocial.atlassian.net/browse/PROD-25687

## :rocket: :fire: Related PRs :fire: :rocket:

This is a PR from a series of 4 PRs that should be merged in the following order: 

1. https://github.com/goalgorilla/open_social_dev/pull/70
2. https://github.com/goalgorilla/open_social/pull/3460
3. https://github.com/goalgorilla/open_social/pull/3457
4. https://github.com/goalgorilla/drupal_social/pull/392 ( this PR )

They are ALL BC and should not cause any breaking change for our local development 
