### PR TITLE
PROD-31149: Remove rector form profil and add it into open_social_dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "require-dev": {
         "composer/composer": "^2",
         "goalgorilla/open_social_dev": "dev-main",
-        "palantirnet/drupal-rector": "^0.15",
         "phpmd/phpmd": "^2.10",
         "squizlabs/html_codesniffer": "*",
         "symplify/easy-coding-standard": "^9.4"


### PR DESCRIPTION
In preparation of Drupal 11 readiness, we move rector form open_social into open_social_dev.

Issue reference:
https://getopensocial.atlassian.net/browse/PROD-31149