### PR TITLE
PROD-31071: Use php8.2.

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,7 +4,7 @@ version: "2"
 
 services:
   web_scripts:
-    image: goalgorilla/open_social_docker:ci-drupal10-php8.1-v2
+    image: goalgorilla/open_social_docker:ci-drupal10-php8.2-v2
     volumes:
       - ./:/var/www:delegated
     depends_on:
@@ -14,7 +14,7 @@ services:
     container_name: social_ci_web_scripts
 
   web:
-    image: goalgorilla/open_social_docker:ci-drupal10-php8.1-v2
+    image: goalgorilla/open_social_docker:ci-drupal10-php8.2-v2
     volumes:
       - ./:/var/www:delegated
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # See: https://github.com/compose-spec/compose-spec/blob/master/spec.md
 services:
   web:
-    image: goalgorilla/open_social_docker:drupal10-php8.1-v2
+    image: goalgorilla/open_social_docker:drupal10-php8.2-v2
     volumes:
       - ./:/var/www:delegated
     depends_on:


### PR DESCRIPTION
In the preparation of Drupal 11 readiness we will start the usage of PHP8.2.

Jira issue: https://getopensocial.atlassian.net/browse/PROD-31071